### PR TITLE
[exception] 공통 예외처리 부분 구현 

### DIFF
--- a/.github/workflows/gradle-server.yml
+++ b/.github/workflows/gradle-server.yml
@@ -8,10 +8,9 @@
 name: Java CI with Gradle
 
 on:
-  push:
-    branches: [ "dev" ]
   pull_request:
     branches: [ "dev" ]
+    paths: ["azit-back/**"]  # azit-back 폴더의 변경사항만 적용
 
 permissions:
   contents: read

--- a/azit-back/.gitignore
+++ b/azit-back/.gitignore
@@ -40,3 +40,6 @@ out/
 ### env ###
 env.yml
 env.properties
+
+### restdocs ###
+src/main/resources/static/docs/index.html

--- a/azit-back/build.gradle
+++ b/azit-back/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '2.7.7'
 	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
-//	id "org.asciidoctor.jvm.convert" version "3.3.2"
+	id "org.asciidoctor.jvm.convert" version "3.3.2"
 }
 
 group = 'com.codestates'
@@ -13,16 +13,16 @@ configurations {
 	compileOnly {
 		extendsFrom annotationProcessor
 	}
-//	asciidoctorExtensions
+	asciidoctorExtensions
 }
 
 repositories {
 	mavenCentral()
 }
 
-//ext {
-//	set('snippetsDir', file("build/generated-snippets"))
-//}
+ext {
+	set('snippetsDir', file("build/generated-snippets"))
+}
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -53,36 +53,32 @@ dependencies {
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 	testImplementation 'org.springframework.security:spring-security-test'
 
-	// asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+	 asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
 }
 
-//tasks.named('asciidoctor') {
-//	configurations "asciidoctorExtensions"
-//	inputs.dir snippetsDir
-//	dependsOn test
-//}
+tasks.named('asciidoctor') {
+	configurations "asciidoctorExtensions"
+	inputs.dir snippetsDir
+	dependsOn test
+}
 
-//task copyDocument(type: Copy) {
-//	dependsOn asciidoctor
-//	from file("${asciidoctor.outputDir}")
-//	into file("src/main/resources/static/docs")
-//}
+task copyDocument(type: Copy) {
+	dependsOn asciidoctor
+	from file("${asciidoctor.outputDir}")
+	into file("src/main/resources/static/docs")
+}
 
-//build {
-//	dependsOn copyDocument
-//}
+build {
+	dependsOn copyDocument
+}
 
-//jar {
-//	enabled = false
-//}
-
-//bootJar {
-//	dependsOn copyDocument
-//	from("${asciidoctor.outputDir}") {
-//		into 'static/docs'
-//	}
-//}
+bootJar {
+	dependsOn copyDocument
+	from("${asciidoctor.outputDir}") {
+		into 'static/docs'
+	}
+}

--- a/azit-back/src/docs/asciidoc/index.adoc
+++ b/azit-back/src/docs/asciidoc/index.adoc
@@ -1,0 +1,24 @@
+= Azit Application Api Documentation
+:sectnums:
+:toc: left
+:toclevels: 4
+:toc-title: Table of Contents
+:source-highlighter: prettify
+
+CAUTION: 요청 Host 주소는 예시입니다. 실제 Host 주소가 아닙니다.
+
+// TODO: 맨 뒤로 배치 예정
+== 에러 코드
+
+=== 커스텀 에러 코드 조회
+.curl-request
+include::{snippets}/exception-code/curl-request.adoc[]
+
+.http-request
+include::{snippets}/exception-code/http-request.adoc[]
+
+.http-response
+include::{snippets}/exception-code/http-response.adoc[]
+
+.exception-code
+include::{snippets}/exception-code/exception-code-fields.adoc[]

--- a/azit-back/src/main/java/com/codestates/azitserver/global/exception/BusinessLogicException.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/global/exception/BusinessLogicException.java
@@ -1,0 +1,15 @@
+package com.codestates.azitserver.global.exception;
+
+import com.codestates.azitserver.global.exception.dto.ExceptionCode;
+
+import lombok.Getter;
+
+public class BusinessLogicException extends RuntimeException {
+	@Getter
+	private final ExceptionCode exceptionCode;
+
+	public BusinessLogicException(ExceptionCode exceptionCode) {
+		super(exceptionCode.getMessage());
+		this.exceptionCode = exceptionCode;
+	}
+}

--- a/azit-back/src/main/java/com/codestates/azitserver/global/exception/advice/GlobalExceptionAdvice.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/global/exception/advice/GlobalExceptionAdvice.java
@@ -1,0 +1,80 @@
+package com.codestates.azitserver.global.exception.advice;
+
+import javax.validation.ConstraintViolationException;
+
+import org.springframework.beans.TypeMismatchException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MultipartException;
+
+import com.codestates.azitserver.global.exception.BusinessLogicException;
+import com.codestates.azitserver.global.exception.dto.ErrorResponse;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionAdvice {
+	@ExceptionHandler
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	public ErrorResponse handleMethodArgumentNotValidException(MethodArgumentNotValidException exception) {
+		log.debug("Method argument not valid exception occurred: {}", exception.getMessage(), exception);
+		final ErrorResponse response = ErrorResponse.of(exception.getBindingResult());
+
+		return response;
+	}
+
+	@ExceptionHandler({
+		IllegalStateException.class, IllegalArgumentException.class, TypeMismatchException.class,
+		HttpMessageNotReadableException.class, MissingServletRequestParameterException.class, MultipartException.class,
+	})
+	public ErrorResponse handleBadRequestException(Exception exception) {
+		log.debug("Bad request exception occurred: {}", exception.getMessage(), exception);
+		ErrorResponse response = ErrorResponse.of(HttpStatus.BAD_REQUEST, exception.getMessage());
+
+		return response;
+	}
+
+	@ExceptionHandler
+	@ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
+	public ErrorResponse handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException exception) {
+		log.debug("Http request method not supported exception occurred: {}", exception.getMessage(), exception);
+		final ErrorResponse response = ErrorResponse.of(HttpStatus.METHOD_NOT_ALLOWED);
+
+		return response;
+	}
+
+	@ExceptionHandler
+	public ResponseEntity<ErrorResponse> handleBusinessLogicException(BusinessLogicException exception) {
+		log.debug("Business logic exception occurred: {}", exception.getMessage(), exception);
+		final ErrorResponse response = ErrorResponse.of(exception.getExceptionCode());
+
+		return new ResponseEntity<>(response, HttpStatus.valueOf(exception.getExceptionCode().getStatus() / 100));
+	}
+
+	@ExceptionHandler
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	public ErrorResponse handleConstraintViolationException(ConstraintViolationException exception) {
+		log.debug("Constraint violation exception occurred: {}", exception.getMessage(), exception);
+		final ErrorResponse response = ErrorResponse.of(exception.getConstraintViolations());
+
+		return response;
+	}
+
+	@ExceptionHandler
+	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+	public ErrorResponse handleException(Exception e) {
+		log.error("Internal server_error occurred: ", e);  // Internal server error는 추가 예외처리가 필요합니다.
+		final ErrorResponse response = ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
+
+		return response;
+	}
+}
+

--- a/azit-back/src/main/java/com/codestates/azitserver/global/exception/controller/ExceptionRestController.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/global/exception/controller/ExceptionRestController.java
@@ -1,0 +1,27 @@
+package com.codestates.azitserver.global.exception.controller;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.codestates.azitserver.global.exception.dto.ExceptionCode;
+
+@RestController
+@RequestMapping("/api/errors")
+public class ExceptionRestController {
+	@GetMapping
+	public ResponseEntity<Map<Object, String>> getAll() {
+		return new ResponseEntity<>(toMap(ExceptionCode.values()), HttpStatus.OK);
+	}
+
+	private Map<Object, String> toMap(ExceptionCode[] values) {
+		return Arrays.stream(values)
+			.collect(Collectors.toMap(ExceptionCode::getStatus, ExceptionCode::getMessage));
+	}
+}

--- a/azit-back/src/main/java/com/codestates/azitserver/global/exception/dto/ErrorResponse.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/global/exception/dto/ErrorResponse.java
@@ -1,0 +1,95 @@
+package com.codestates.azitserver.global.exception.dto;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.validation.ConstraintViolation;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.BindingResult;
+
+import lombok.Getter;
+
+@Getter
+public class ErrorResponse {
+	private int status;
+	private String message;
+	private List<FieldError> fieldErrors;
+	private List<ConstraintViolationError> violationErrors;
+
+	private ErrorResponse(int status, String message) {
+		this.status = status;
+		this.message = message;
+	}
+
+	private ErrorResponse(List<FieldError> fieldErrors, List<ConstraintViolationError> violationErrors) {
+		this.fieldErrors = fieldErrors;
+		this.violationErrors = violationErrors;
+	}
+
+	public static ErrorResponse of(BindingResult bindingResult) {
+		return new ErrorResponse(FieldError.of(bindingResult), null);
+	}
+
+	public static ErrorResponse of(Set<ConstraintViolation<?>> violations) {
+		return new ErrorResponse(null, ConstraintViolationError.of(violations));
+	}
+
+	public static ErrorResponse of(ExceptionCode exceptionCode) {
+		return new ErrorResponse(exceptionCode.getStatus(), exceptionCode.getMessage());
+	}
+
+	public static ErrorResponse of(HttpStatus httpStatus) {
+		return new ErrorResponse(httpStatus.value(), httpStatus.getReasonPhrase());
+	}
+
+	public static ErrorResponse of(HttpStatus httpStatus, String message) {
+		return new ErrorResponse(httpStatus.value(), message);
+	}
+
+	@Getter
+	public static class FieldError {
+		private final String field;
+		private final Object rejectedValue;
+		private final String message;
+
+		private FieldError(String field, Object rejectedValue, String message) {
+			this.field = field;
+			this.rejectedValue = rejectedValue;
+			this.message = message;
+		}
+
+		public static List<FieldError> of(BindingResult bindingResult) {
+			List<org.springframework.validation.FieldError> fieldErrors = bindingResult.getFieldErrors();
+			return fieldErrors.stream()
+				.map(error -> new FieldError(
+					error.getField(),
+					error.getRejectedValue() == null ? "" : error.getRejectedValue().toString(),
+					error.getDefaultMessage()))
+				.collect(Collectors.toList());
+		}
+	}
+
+	@Getter
+	private static class ConstraintViolationError {
+		private final String propertyPath;
+		private final Object invalidValue;
+		private final String message;
+
+		private ConstraintViolationError(String propertyPath, Object invalidValue, String message) {
+			this.propertyPath = propertyPath;
+			this.invalidValue = invalidValue;
+			this.message = message;
+		}
+
+		public static List<ConstraintViolationError> of(Set<ConstraintViolation<?>> constraintViolations) {
+			return constraintViolations.stream()
+				.map(error -> new ConstraintViolationError(
+					error.getPropertyPath().toString(),
+					error.getInvalidValue().toString(),
+					error.getMessage()))
+				.collect(Collectors.toList());
+		}
+	}
+}

--- a/azit-back/src/main/java/com/codestates/azitserver/global/exception/dto/ExceptionCode.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/global/exception/dto/ExceptionCode.java
@@ -1,0 +1,21 @@
+package com.codestates.azitserver.global.exception.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * - status는 status code + status id로 작성합니다. <br>
+ * - message는 에러에 관한 구체적인 메세지를 작성합니다
+ */
+@Getter
+@AllArgsConstructor
+public enum ExceptionCode {
+	// 404
+	MEMBER_NOT_FOUND(40401, "Member not found"),
+	CLUB_NOT_FOUND(40402, "Club not found");
+
+	// 500
+
+	final int status;
+	final String message;
+}

--- a/azit-back/src/test/java/com/codestates/azitserver/config/CustomExceptionCodeSnippet.java
+++ b/azit-back/src/test/java/com/codestates/azitserver/config/CustomExceptionCodeSnippet.java
@@ -1,0 +1,32 @@
+package com.codestates.azitserver.config;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.operation.Operation;
+import org.springframework.restdocs.payload.AbstractFieldsSnippet;
+import org.springframework.restdocs.payload.FieldDescriptor;
+
+public class CustomExceptionCodeSnippet extends AbstractFieldsSnippet {
+	public CustomExceptionCodeSnippet(String type, List<FieldDescriptor> descriptors, Map<String, Object> attributes,
+		boolean ignoreUndocumentedFields) {
+		super(type, descriptors, attributes, ignoreUndocumentedFields);
+	}
+
+	public CustomExceptionCodeSnippet(String name, String type, List<FieldDescriptor> descriptors,
+		Map<String, Object> attributes, boolean ignoreUndocumentedFields) {
+		super(name, type, descriptors, attributes, ignoreUndocumentedFields);
+	}
+
+	@Override
+	protected MediaType getContentType(Operation operation) {
+		return operation.getResponse().getHeaders().getContentType();
+	}
+
+	@Override
+	protected byte[] getContent(Operation operation) throws IOException {
+		return operation.getResponse().getContent();
+	}
+}

--- a/azit-back/src/test/java/com/codestates/azitserver/global/exception/controller/ExceptionRestControllerTest.java
+++ b/azit-back/src/test/java/com/codestates/azitserver/global/exception/controller/ExceptionRestControllerTest.java
@@ -1,0 +1,70 @@
+package com.codestates.azitserver.global.exception.controller;
+
+import static com.codestates.azitserver.global.utils.AsciiDocsUtils.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.snippet.Attributes.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.codestates.azitserver.config.CustomExceptionCodeSnippet;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@WebMvcTest(value = ExceptionRestController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+@AutoConfigureRestDocs
+class ExceptionRestControllerTest {
+	@Autowired
+	MockMvc mockMvc;
+
+	@Autowired
+	ObjectMapper objectMapper;
+
+	@Test
+	void getAll() throws Exception {
+		// given
+		// when
+		ResultActions actions = mockMvc.perform(get("/api/errors"));
+
+		// then
+		MvcResult result = actions.andReturn();
+		Map<Object, String> errors = objectMapper.readValue(
+			result.getResponse().getContentAsByteArray(), new TypeReference<>() {
+			});
+
+		actions
+			.andDo(print())
+			.andDo(
+				getDefaultDocument(
+					"exception-code",
+					new CustomExceptionCodeSnippet(
+						"exception-code",
+						getDescriptors(errors),
+						attributes(key("title").value("ExceptionCode")),
+						true
+					)
+				)
+			);
+	}
+
+	private List<FieldDescriptor> getDescriptors(Map<Object, String> errors) {
+		return errors.entrySet().stream()
+			.map(error -> fieldWithPath(error.getKey().toString()).description(error.getValue()))
+			.collect(Collectors.toList());
+	}
+}

--- a/azit-back/src/test/java/com/codestates/azitserver/global/utils/AsciiDocsUtils.java
+++ b/azit-back/src/test/java/com/codestates/azitserver/global/utils/AsciiDocsUtils.java
@@ -1,0 +1,33 @@
+package com.codestates.azitserver.global.utils;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor;
+import org.springframework.restdocs.operation.preprocess.OperationResponsePreprocessor;
+import org.springframework.restdocs.snippet.Snippet;
+
+public class AsciiDocsUtils {
+	public static OperationRequestPreprocessor getRequestPreProcessor() {
+		return preprocessRequest(
+			modifyUris()  // api docs 상에 도메인 주소를 바꾸기 위해 사용합니다.
+				.scheme("https")
+				.host("azit-docs.api.com")
+				.removePort(),
+			prettyPrint());
+	}
+
+	public static OperationResponsePreprocessor getResponsePreProcessor() {
+		return preprocessResponse(prettyPrint());
+	}
+
+	public static RestDocumentationResultHandler getDefaultDocument(String identifier, Snippet... snippets) {
+		return document(
+			identifier,
+			getRequestPreProcessor(),
+			getResponsePreProcessor(),
+			snippets
+		);
+	}
+}

--- a/azit-back/src/test/resources/org/springframework/restdocs/templates/exception-code-fields.snippet
+++ b/azit-back/src/test/resources/org/springframework/restdocs/templates/exception-code-fields.snippet
@@ -1,0 +1,9 @@
+|===
+|Code|Description
+
+{{#fields}}
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`{{description}}`{{/tableCellContent}}
+{{/fields}}
+
+|===


### PR DESCRIPTION
## 개요
issue [#9 ]
공통 예외처리 로직 구현하였습니다. 예외처리 코드는 코드스테이츠 교육내용을 바탕으로 작성되었습니다.
`BusinessLogicException`사용시 적절하게 `ExceptionCode` 추가하셔서 사용하시면 됩니다.

더불어 테스트 코드 작성시 일부 공통 기능을 클래스화한 `AsciiDocsUtils.java` 또한 api문서 작성시 이용 가능합니다.

## 주요 작업사항
- `BusinessLogicException` 및 `ExceptionCode` 작성
- 예외 사항 발생시 응답값을 던져주는 `ErrorResponse` 작성
- 예외 사항 발생시 가로채서 예외사항을 핸들링하는 Advice 작성
- api 문서 작성

## 기능 외 변경사항(개발 범위 외 수정된 사항 등)
- 풀리퀘시 front, back 상관 없이 서버 배포가 이루어지는 것을 방지하기 위해 백엔드 폴더에 PR 이벤트가 생겼을시에만 배포를 진행하는 코드를 추가하였습니다.(안 될수도 있음. 안 되면 계속 수정 예정.)
- 테스트 코드에 api 문서 작성 로직이 추가됨에 따라 build.gradle에서 주석처리되었언 asciidocs 부분으 주석을 해제하였습니다.

## 기타
- `ExceptionRestController.java`에서 응답시 에러 코드를 map으로 던져주는 과정에서 응답코드가 중복되어 제대로 에러 코드를 뱉어내지 못하는 것을 방지하기 위해 `ExceptionCode.java`의 status 값을 http status + id로 기입해주시면 감사하겠습니다.