### PR TITLE
[club] 아지트 CRUD 구현 - 아지트 생성 구현

### DIFF
--- a/azit-back/src/docs/asciidoc/index.adoc
+++ b/azit-back/src/docs/asciidoc/index.adoc
@@ -7,6 +7,33 @@
 
 CAUTION: 요청 Host 주소는 예시입니다. 실제 Host 주소가 아닙니다.
 
+
+== 아지트(모임)
+
+=== 아지트 생성
+.curl-request
+include::{snippets}/post-club/curl-request.adoc[]
+
+.http-request
+include::{snippets}/post-club/http-request.adoc[]
+
+.request-headers
+include::{snippets}/post-club/request-headers.adoc[]
+
+.request-parts
+include::{snippets}/post-club/request-parts.adoc[]
+
+.request-part-data-fields
+include::{snippets}/post-club/request-part-data-fields.adoc[]
+
+.http-response
+include::{snippets}/post-club/http-response.adoc[]
+
+.response-fields
+include::{snippets}/post-club/response-fields.adoc[]
+
+
+
 // TODO: 맨 뒤로 배치 예정
 == 에러 코드
 

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/club/controller/ClubController.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/club/controller/ClubController.java
@@ -1,0 +1,43 @@
+package com.codestates.azitserver.domain.club.controller;
+
+import javax.validation.Valid;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.codestates.azitserver.domain.club.dto.ClubDto;
+import com.codestates.azitserver.domain.club.entity.Club;
+import com.codestates.azitserver.domain.club.mapper.ClubMapper;
+import com.codestates.azitserver.domain.club.service.ClubService;
+import com.codestates.azitserver.global.dto.SingleResponseDto;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/clubs")
+public class ClubController {
+	private final ClubMapper mapper;
+	private final ClubService clubService;
+
+	@PostMapping(consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+	public ResponseEntity<?> postClub(@Valid @RequestPart(name = "data") ClubDto.Post post,
+		@RequestPart(name = "image", required=false) MultipartFile avatarImage) {
+		Club toClub = mapper.clubDtoPostToClubEntity(post);
+		Club club = clubService.createClub(toClub, avatarImage);
+		ClubDto.Response response = mapper.clubToClubDtoResponse(club);
+
+		return new ResponseEntity<>(new SingleResponseDto<>(response), HttpStatus.CREATED);
+
+	}
+}

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/club/dto/ClubDto.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/club/dto/ClubDto.java
@@ -1,0 +1,92 @@
+package com.codestates.azitserver.domain.club.dto;
+
+import java.time.LocalDateTime;
+
+import javax.validation.constraints.FutureOrPresent;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.PositiveOrZero;
+
+import org.hibernate.validator.constraints.Length;
+import org.hibernate.validator.constraints.Range;
+
+import com.codestates.azitserver.domain.club.entity.Club;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+public class ClubDto {
+	@Getter
+	@Setter
+	@NoArgsConstructor
+	public static class Post {
+		@NotBlank(message = "The club name must not be null")
+		@Length(max = 24, message = "The club name must be less than 24 characters.")
+		private String clubName;
+
+		@NotBlank
+		@Length(max = 128, message = "The club information must be less than 128 characters.")
+		private String clubInfo;
+
+		@NotNull
+		@Range(min = 3, max = 20, message = "The participant limit is between 3 and 20")
+		private Integer memberLimit;
+
+		@NotNull
+		@PositiveOrZero(message = "The participation fee cannot be negative. ")
+		private Integer fee;
+
+		@NotNull
+		private Club.JoinMethod joinMethod;
+
+		@Length(min = 4, max = 4, message = "Birth year must be 4 digit number.")
+		@Pattern(regexp = "\\d{4}", message = "The birth year must be 4 digit number.")
+		private String birthYearMin;
+
+		@Length(min = 4, max = 4, message = "Birth year must be 4 digit number.")
+		@Pattern(regexp = "\\d{4}", message = "The birth year must be 4 digit number.")
+		private String birthYearMax;
+
+		@NotNull
+		private Club.GenderRestriction genderRestriction;
+
+		@NotNull
+		@FutureOrPresent(message = "Appointment date cannot be in the past." )
+		private LocalDateTime meetingDate;
+
+		@NotNull
+		private Boolean isOnline;
+
+		private String location;
+
+		@NotNull
+		@Length(max = 24, message = "The join question must be less than 24 characters.")
+		private String joinQuestion;
+
+		// TODO : 연관관계 매핑
+
+		// private Long hostId;
+		// private List<Long> categories;
+	}
+
+	@Getter
+	@Setter
+	public static class Response {
+		private Long clubId;
+		private String clubName;
+		private String clubInfo;
+		private Integer memberLimit;
+		private Integer fee;
+		private Club.JoinMethod joinMethod;
+		private String birthYearMin;
+		private String birthYearMax;
+		private Club.GenderRestriction genderRestriction;
+		private LocalDateTime meetingDate;
+		private Boolean isOnline;
+		private String location;
+		private String joinQuestion;
+		private Club.ClubStatus clubStatus;
+	}
+}

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/club/entity/Club.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/club/entity/Club.java
@@ -1,4 +1,106 @@
 package com.codestates.azitserver.domain.club.entity;
 
-public class Club {
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+import com.codestates.azitserver.domain.common.Auditable;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+public class Club extends Auditable {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long clubId;
+
+	@Column(name = "CLUB_NAME", nullable = false, length = 24)
+	private String clubName;
+
+	@Column(name = "CLUB_INFO", nullable = false, length = 128)
+	private String clubInfo;
+
+	@Column(name = "MEMBER_LIMIT", nullable = false)
+	private Integer memberLimit;
+
+	@Column(name = "FEE", nullable = false)
+	private Integer fee = 0;
+
+	@Enumerated(value = EnumType.STRING)
+	@Column(name = "JOIN_METHOD", nullable = false, updatable = false, length = 24)
+	private JoinMethod joinMethod = JoinMethod.APPROVAL;
+
+	@Column(name = "BIRTH_YEAR_MIN", nullable = false, length = 4)
+	private String birthYearMin;
+
+	@Column(name = "BIRTH_YEAR_MAX", nullable = false, length = 4)
+	private String birthYearMax;
+
+	@Enumerated(value = EnumType.STRING)
+	@Column(name = "GENDER_RESTRICTION", nullable = false)
+	private GenderRestriction genderRestriction;
+
+	@Column(name = "MEETING_DATE", nullable = false)
+	private LocalDateTime meetingDate;
+
+	@Column(name = "IS_ONLINE", nullable = false)
+	private Boolean isOnline;
+
+	@Column(name = "LOCATION", length = 24)
+	private String location;
+
+	@Column(name = "JOIN_QUESTION", nullable = false, updatable = false, length = 24)
+	private String joinQuestion;
+
+	@Enumerated(value = EnumType.STRING)
+	@Column(name = "CLUB_STATUS", nullable = false)
+	private ClubStatus clubStatus = ClubStatus.CLUB_ACTIVE;
+
+	// TODO: category(updatable = false), banner_image, host_id, club_members
+
+	public enum JoinMethod {
+		APPROVAL("승인제"),
+		FIRST_COME("선착순");
+
+		@Getter
+		private final String method;
+
+		JoinMethod(String method) {
+			this.method = method;
+		}
+	}
+
+	public enum GenderRestriction {
+		MALE_ONLY("남자만"),
+		FEMALE_ONLY("여자만"),
+		ALL("상관없음");
+
+		@Getter
+		private final String restrictionType;
+
+		GenderRestriction(String restrictionType) {
+			this.restrictionType = restrictionType;
+		}
+	}
+
+	public enum ClubStatus {
+		CLUB_ACTIVE("아지트 활동중"),
+		CLUB_CANCEL("아지트 취소됨");
+
+		@Getter
+		private final String status;
+
+		ClubStatus(String status) {
+			this.status = status;
+		}
+	}
 }

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/club/mapper/ClubMapper.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/club/mapper/ClubMapper.java
@@ -1,0 +1,16 @@
+package com.codestates.azitserver.domain.club.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import com.codestates.azitserver.domain.club.dto.ClubDto;
+import com.codestates.azitserver.domain.club.entity.Club;
+
+@Mapper(componentModel = "spring")
+public interface ClubMapper {
+	@Mapping(target = "clubId", ignore = true)
+	@Mapping(target = "clubStatus", ignore = true)
+	Club clubDtoPostToClubEntity(ClubDto.Post post);
+
+	ClubDto.Response clubToClubDtoResponse(Club club);
+}

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/club/repository/ClubRepository.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/club/repository/ClubRepository.java
@@ -1,0 +1,8 @@
+package com.codestates.azitserver.domain.club.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.codestates.azitserver.domain.club.entity.Club;
+
+public interface ClubRepository extends JpaRepository<Club, Long> {
+}

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/club/service/ClubService.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/club/service/ClubService.java
@@ -1,0 +1,24 @@
+package com.codestates.azitserver.domain.club.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.codestates.azitserver.domain.club.entity.Club;
+import com.codestates.azitserver.domain.club.repository.ClubRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ClubService {
+	private final ClubRepository clubRepository;
+
+	public Club createClub(Club toClub, MultipartFile avatarImage) {
+		// 온라인 여부에 따른 null 또는 주소값 저장
+		toClub.setLocation(toClub.getIsOnline() ? null : toClub.getLocation());
+
+		// TODO : avatar image 처리 로직 필요
+
+		return clubRepository.save(toClub);
+	}
+}

--- a/azit-back/src/test/java/com/codestates/azitserver/domain/club/controller/ClubControllerTest.java
+++ b/azit-back/src/test/java/com/codestates/azitserver/domain/club/controller/ClubControllerTest.java
@@ -1,0 +1,142 @@
+package com.codestates.azitserver.domain.club.controller;
+
+import static com.codestates.azitserver.global.utils.AsciiDocsUtils.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.payload.ResponseFieldsSnippet;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.codestates.azitserver.domain.club.dto.ClubDto;
+import com.codestates.azitserver.domain.club.entity.Club;
+import com.codestates.azitserver.domain.club.mapper.ClubMapper;
+import com.codestates.azitserver.domain.club.service.ClubService;
+import com.codestates.azitserver.domain.stub.ClubStubData;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@AutoConfigureRestDocs
+@AutoConfigureMockMvc(addFilters = false)
+@MockBean(JpaMetamodelMappingContext.class)
+@WebMvcTest(controllers = ClubController.class, excludeAutoConfiguration = SecurityAutoConfiguration.class)
+class ClubControllerTest implements ClubControllerTestHelper {
+	@Autowired
+	MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockBean
+	ClubService clubService;
+
+	@MockBean
+	ClubMapper mapper;
+
+	Club club;
+	ClubDto.Post post;
+	ClubDto.Response response;
+
+	@BeforeEach
+	void beforeEach() {
+		// Make stub data
+		club = ClubStubData.getDefaultClub();
+		post = ClubStubData.getClubDtoPost();
+		response = ClubStubData.getClubDtoResponse();
+	}
+
+	@Test
+	void postClub() throws Exception {
+		// given
+		MockMultipartFile image = new MockMultipartFile(
+			"image",
+			"hello-world.png",
+			MediaType.MULTIPART_FORM_DATA_VALUE,
+			"".getBytes()
+		);
+
+		String content = objectMapper.writeValueAsString(post);
+		MockMultipartFile data = new MockMultipartFile(
+			"data",
+			"",
+			MediaType.APPLICATION_JSON_VALUE,
+			content.getBytes()
+		);
+
+		given(mapper.clubDtoPostToClubEntity(Mockito.any(ClubDto.Post.class))).willReturn(club);
+		given(clubService.createClub(Mockito.any(Club.class), any())).willReturn(club);
+		given(mapper.clubToClubDtoResponse(Mockito.any(Club.class))).willReturn(response);
+
+		// when
+		ResultActions actions = mockMvc.perform(postMultipartRequestBuilder(getClubUrl(), image, data)
+			.header("Authorization", "Required JWT access token"));
+
+		// then
+		actions.andDo(print())
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.data.clubId").value(1))
+			.andDo(getDefaultDocument(
+					"post-club",
+					requestHeaders(headerWithName("Authorization").description("Jwt Access Token")),
+					requestParts(List.of(
+						partWithName("data").description("data"),
+						partWithName("image").description("image").optional())),
+					requestPartFields("data",
+						fieldWithPath("clubName").type(JsonFieldType.STRING).description("아지트 이름"),
+						fieldWithPath("clubInfo").type(JsonFieldType.STRING).description("아지트 소개"),
+						fieldWithPath("memberLimit").type(JsonFieldType.NUMBER).description("참가 인원 제한"),
+						fieldWithPath("fee").type(JsonFieldType.NUMBER).description("참가비"),
+						fieldWithPath("joinMethod").type(JsonFieldType.STRING).description("참가 방식 [ APPROVAL | FIRST_COME ]"),
+						fieldWithPath("birthYearMin").type(JsonFieldType.STRING).description("최소 년생 제한"),
+						fieldWithPath("birthYearMax").type(JsonFieldType.STRING).description("최대 년생 제한"),
+						fieldWithPath("genderRestriction").type(JsonFieldType.STRING).description("성별 제한 [ MALE_ONLY | FEMALE_ONLY | ALL ]"),
+						fieldWithPath("meetingDate").type(JsonFieldType.STRING).description("날짜 및 시간"),
+						fieldWithPath("isOnline").type(JsonFieldType.BOOLEAN).description("만남 타입 [ true : 온라인 | false : 오프라인 ]"),
+						fieldWithPath("location").type(JsonFieldType.STRING).description("오프라인 만남 장소"),
+						fieldWithPath("joinQuestion").type(JsonFieldType.STRING).description("참가 신청 질문")
+						),
+					getSingleResponseSnippet()
+				)
+			);
+
+	}
+
+	public static ResponseFieldsSnippet getSingleResponseSnippet() {
+		return responseFields(
+			fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터")
+		).andWithPrefix("data.",
+			fieldWithPath("clubId").type(JsonFieldType.NUMBER).description("아지트 고유 식별자"),
+			fieldWithPath("clubName").type(JsonFieldType.STRING).description("아지트 이름"),
+			fieldWithPath("clubInfo").type(JsonFieldType.STRING).description("아지트 소개"),
+			fieldWithPath("memberLimit").type(JsonFieldType.NUMBER).description("참가 인원 제한"),
+			fieldWithPath("fee").type(JsonFieldType.NUMBER).description("참가비"),
+			fieldWithPath("joinMethod").type(JsonFieldType.STRING).description("참가 방식 [ APPROVAL | FIRST_COME ]"),
+			fieldWithPath("birthYearMin").type(JsonFieldType.STRING).description("최소 년생 제한"),
+			fieldWithPath("birthYearMax").type(JsonFieldType.STRING).description("최대 년생 제한"),
+			fieldWithPath("genderRestriction").type(JsonFieldType.STRING).description("성별 제한 [ MALE_ONLY | FEMALE_ONLY | ALL ]"),
+			fieldWithPath("meetingDate").type(JsonFieldType.STRING).description("날짜 및 시간"),
+			fieldWithPath("isOnline").type(JsonFieldType.BOOLEAN).description("만남 타입 [ true : 온라인 | false : 오프라인 ]"),
+			fieldWithPath("location").type(JsonFieldType.STRING).description("오프라인 만남 장소"),
+			fieldWithPath("joinQuestion").type(JsonFieldType.STRING).description("참가 신청 질문"),
+			fieldWithPath("clubStatus").type(JsonFieldType.STRING).description("아지트 활성화 상태 [ CLUB_ACTIVE | CLUB_CANCEL ]")
+		);
+	}
+}

--- a/azit-back/src/test/java/com/codestates/azitserver/domain/club/controller/ClubControllerTestHelper.java
+++ b/azit-back/src/test/java/com/codestates/azitserver/domain/club/controller/ClubControllerTestHelper.java
@@ -1,0 +1,11 @@
+package com.codestates.azitserver.domain.club.controller;
+
+import com.codestates.azitserver.global.utils.ControllerTestHelper;
+
+public interface ClubControllerTestHelper extends ControllerTestHelper {
+	String CLUB_URL = "/api/clubs";
+
+	default String getClubUrl() {
+		return CLUB_URL;
+	}
+}

--- a/azit-back/src/test/java/com/codestates/azitserver/domain/stub/ClubStubData.java
+++ b/azit-back/src/test/java/com/codestates/azitserver/domain/stub/ClubStubData.java
@@ -1,0 +1,68 @@
+package com.codestates.azitserver.domain.stub;
+
+import java.time.LocalDateTime;
+
+import com.codestates.azitserver.domain.club.dto.ClubDto;
+import com.codestates.azitserver.domain.club.entity.Club;
+
+public class ClubStubData {
+	public static Club getDefaultClub() {
+		Club club = new Club();
+
+		club.setClubId(1L);
+		club.setClubName("재밌는 아지트");
+		club.setClubInfo("재밌는 아지트입니다.");
+		club.setMemberLimit(4);
+		club.setFee(10000);
+		club.setJoinMethod(Club.JoinMethod.APPROVAL);
+		club.setBirthYearMin("1990");
+		club.setBirthYearMax("2000");
+		club.setGenderRestriction(Club.GenderRestriction.ALL);
+		club.setMeetingDate(LocalDateTime.now().plusDays(1));
+		club.setIsOnline(false);
+		club.setLocation("서울시 송파구");
+		club.setJoinQuestion("재밌는 아지트 맞을까요?");
+		club.setClubStatus(Club.ClubStatus.CLUB_ACTIVE);
+
+		return club;
+	}
+
+	public static ClubDto.Post getClubDtoPost() {
+		ClubDto.Post post = new ClubDto.Post();
+		post.setClubName("재밌는 아지트");
+		post.setClubInfo("재밌는 아지트입니다.");
+		post.setMemberLimit(4);
+		post.setFee(10000);
+		post.setJoinMethod(Club.JoinMethod.APPROVAL);
+		post.setBirthYearMin("1990");
+		post.setBirthYearMax("2000");
+		post.setGenderRestriction(Club.GenderRestriction.ALL);
+		post.setMeetingDate(LocalDateTime.now().plusDays(1));
+		post.setIsOnline(false);
+		post.setLocation("서울시 송파구");
+		post.setJoinQuestion("재밌는 아지트 맞을까요?");
+
+		return post;
+	}
+
+	public static ClubDto.Response getClubDtoResponse() {
+		ClubDto.Response response = new ClubDto.Response();
+
+		response.setClubId(1L);
+		response.setClubName("재밌는 아지트");
+		response.setClubInfo("재밌는 아지트입니다.");
+		response.setMemberLimit(4);
+		response.setFee(10000);
+		response.setJoinMethod(Club.JoinMethod.APPROVAL);
+		response.setBirthYearMin("1990");
+		response.setBirthYearMax("2000");
+		response.setGenderRestriction(Club.GenderRestriction.ALL);
+		response.setMeetingDate(LocalDateTime.now().plusDays(1));
+		response.setIsOnline(false);
+		response.setLocation("서울시 송파구");
+		response.setJoinQuestion("재밌는 아지트 맞을까요?");
+		response.setClubStatus(Club.ClubStatus.CLUB_ACTIVE);
+
+		return response;
+	}
+}

--- a/azit-back/src/test/java/com/codestates/azitserver/global/utils/ControllerTestHelper.java
+++ b/azit-back/src/test/java/com/codestates/azitserver/global/utils/ControllerTestHelper.java
@@ -1,0 +1,16 @@
+package com.codestates.azitserver.global.utils;
+
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+public interface ControllerTestHelper {
+	default MockHttpServletRequestBuilder postMultipartRequestBuilder(String url, MockMultipartFile file1, MockMultipartFile file2) {
+		return multipart(url)
+			.file(file1)
+			.file(file2)
+			.accept(MediaType.APPLICATION_JSON);
+	}
+}


### PR DESCRIPTION
## 개요
issue [#16 ] 중
아지트 CRUD 중 생성 부분 우선 완료하여 리뷰 요청드립니다.
multipart/form-data 형식의 요청 테스트 코드가 생각보다 오래 걸렸네요ㅠ

## 주요 작업사항
- Club 중 아지트 생성 부분 완료(Entity, Controller, Service 등)
- 아지트 생성에 대한 테스트 코드 및 api 문서화 완료
- 컨트롤러 테스트에 유용한 util 클래스 작성중

## 기능 외 변경사항(개발 범위 외 수정된 사항 등)

## 기타
- [ControllerTestHelper.java](azit-back/src/test/java/com/codestates/azitserver/global/utils/ControllerTestHelper.java) 클래스에 컨트롤러 단위 테스트 중 요청 관련된 메서드를 공통화 하고 있습니다. 참고하셔서 추후 테스트 코드 작성시 유용하게 쓰세요~