### PR TITLE
[club] 아지트 CRUD 구현 - 클럽 정보 수정 및 예약 취소 기능 구현

### DIFF
--- a/azit-back/src/docs/asciidoc/index.adoc
+++ b/azit-back/src/docs/asciidoc/index.adoc
@@ -32,6 +32,43 @@ include::{snippets}/post-club/http-response.adoc[]
 .response-fields
 include::{snippets}/post-club/response-fields.adoc[]
 
+=== 아지트 정보 수정
+.curl-request
+include::{snippets}/patch-club/curl-request.adoc[]
+
+.http-request
+include::{snippets}/patch-club/http-request.adoc[]
+
+.path-parameters
+include::{snippets}/patch-club/path-parameters.adoc[]
+
+.request-parts
+include::{snippets}/patch-club/request-parts.adoc[]
+
+.request-part-data-fields
+include::{snippets}/patch-club/request-part-data-fields.adoc[]
+
+.http-response
+include::{snippets}/patch-club/http-response.adoc[]
+
+.response-fields
+include::{snippets}/patch-club/response-fields.adoc[]
+
+=== 아지트 예약 취소
+.curl-request
+include::{snippets}/delete-club/curl-request.adoc[]
+
+.http-request
+include::{snippets}/delete-club/http-request.adoc[]
+
+.path-parameters
+include::{snippets}/delete-club/path-parameters.adoc[]
+
+.http-response
+include::{snippets}/delete-club/http-response.adoc[]
+
+.response-fields
+include::{snippets}/delete-club/response-fields.adoc[]
 
 
 // TODO: 맨 뒤로 배치 예정

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/club/controller/ClubController.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/club/controller/ClubController.java
@@ -1,11 +1,15 @@
 package com.codestates.azitserver.domain.club.controller;
 
 import javax.validation.Valid;
+import javax.validation.constraints.Positive;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -32,12 +36,32 @@ public class ClubController {
 
 	@PostMapping(consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
 	public ResponseEntity<?> postClub(@Valid @RequestPart(name = "data") ClubDto.Post post,
-		@RequestPart(name = "image", required=false) MultipartFile avatarImage) {
+		@RequestPart(name = "image", required = false) MultipartFile bannerImage) {
 		Club toClub = mapper.clubDtoPostToClubEntity(post);
-		Club club = clubService.createClub(toClub, avatarImage);
+		Club club = clubService.createClub(toClub, bannerImage);
 		ClubDto.Response response = mapper.clubToClubDtoResponse(club);
 
 		return new ResponseEntity<>(new SingleResponseDto<>(response), HttpStatus.CREATED);
 
+	}
+
+	@PatchMapping("/{club-id}")
+	public ResponseEntity<?> patchClub(@Positive @PathVariable("club-id") Long clubId,
+		@Valid @RequestPart(name = "data") ClubDto.Patch patch,
+		@RequestPart(name = "image", required = false) MultipartFile bannerImage) {
+		patch.setClubId(clubId);
+		Club toClub = mapper.clubDtoPatchToClubEntity(patch);
+		Club club = clubService.updateClub(toClub, bannerImage);
+		ClubDto.Response response = mapper.clubToClubDtoResponse(club);
+
+		return new ResponseEntity<>(new SingleResponseDto<>(response), HttpStatus.OK);
+	}
+
+	@DeleteMapping("/{club-id}")
+	public ResponseEntity<?> deleteClub(@Positive @PathVariable("club-id") Long clubId) {
+		Club club = clubService.cancelClub(clubId);
+		ClubDto.Response response = mapper.clubToClubDtoResponse(club);
+
+		return new ResponseEntity<>(new SingleResponseDto<>(response), HttpStatus.ACCEPTED);
 	}
 }

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/club/dto/ClubDto.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/club/dto/ClubDto.java
@@ -12,6 +12,7 @@ import org.hibernate.validator.constraints.Length;
 import org.hibernate.validator.constraints.Range;
 
 import com.codestates.azitserver.domain.club.entity.Club;
+import com.codestates.azitserver.global.validator.NotSpace;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -69,6 +70,54 @@ public class ClubDto {
 
 		// private Long hostId;
 		// private List<Long> categories;
+		// private String bannerImageUrl;
+	}
+
+	/**
+	 * - 항시수정 가능항목 : clubInfo, bannerImageUrl, genderRestriction, birthYearMin, birthYearMax, fee
+	 * <br>
+	 * - 수정 제한 항목(신청자 또는 참가자 있을시) : clubName, memberLimit, meetingDate, isOnline,location
+	 * <br>
+	 * - 수정 불가 항목 : joinQuestion, categories, joinMethod
+	 */
+	@Getter
+	@Setter
+	@NoArgsConstructor
+	public static class Patch {
+		private Long clubId;
+
+		@NotSpace(message = "The club name must not be empty space")
+		@Length(max = 24, message = "The club name must be less than 24 characters.")
+		private String clubName;
+
+		@NotSpace(message = "The club information must not be empty space")
+		@Length(max = 128, message = "The club information must be less than 128 characters.")
+		private String clubInfo;
+
+		@Range(min = 3, max = 20, message = "The participant limit is between 3 and 20")
+		private Integer memberLimit;
+
+		@PositiveOrZero(message = "The participation fee cannot be negative. ")
+		private Integer fee;
+
+		@Length(min = 4, max = 4, message = "Birth year must be 4 digit number.")
+		@Pattern(regexp = "\\d{4}", message = "The birth year must be 4 digit number.")
+		private String birthYearMin;
+
+		@Length(min = 4, max = 4, message = "Birth year must be 4 digit number.")
+		@Pattern(regexp = "\\d{4}", message = "The birth year must be 4 digit number.")
+		private String birthYearMax;
+
+		private Club.GenderRestriction genderRestriction;
+
+		@FutureOrPresent(message = "Appointment date cannot be in the past." )
+		private LocalDateTime meetingDate;
+
+		private Boolean isOnline;
+
+		private String location;
+
+		// private String bannerImageUrl;
 	}
 
 	@Getter

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/club/mapper/ClubMapper.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/club/mapper/ClubMapper.java
@@ -12,5 +12,10 @@ public interface ClubMapper {
 	@Mapping(target = "clubStatus", ignore = true)
 	Club clubDtoPostToClubEntity(ClubDto.Post post);
 
+	@Mapping(target = "joinMethod", ignore = true)
+	@Mapping(target = "joinQuestion", ignore = true)
+	@Mapping(target = "clubStatus", ignore = true)
+	Club clubDtoPatchToClubEntity(ClubDto.Patch patch);
+
 	ClubDto.Response clubToClubDtoResponse(Club club);
 }

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/club/service/ClubService.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/club/service/ClubService.java
@@ -1,10 +1,15 @@
 package com.codestates.azitserver.domain.club.service;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.codestates.azitserver.domain.club.entity.Club;
 import com.codestates.azitserver.domain.club.repository.ClubRepository;
+import com.codestates.azitserver.domain.common.CustomBeanUtils;
+import com.codestates.azitserver.global.exception.BusinessLogicException;
+import com.codestates.azitserver.global.exception.dto.ExceptionCode;
 
 import lombok.RequiredArgsConstructor;
 
@@ -12,13 +17,44 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ClubService {
 	private final ClubRepository clubRepository;
+	private final CustomBeanUtils<Club> beanUtils;
 
-	public Club createClub(Club toClub, MultipartFile avatarImage) {
+	public Club createClub(Club toClub, MultipartFile bannerImage) {
 		// 온라인 여부에 따른 null 또는 주소값 저장
 		toClub.setLocation(toClub.getIsOnline() ? null : toClub.getLocation());
 
-		// TODO : avatar image 처리 로직 필요
+		// TODO : banner image에 대한 처리 로직이 필요합니다.
 
 		return clubRepository.save(toClub);
+	}
+
+	/**
+	 * - 수정 제한 항목(신청자 또는 참가자 있을시) : clubName, memberLimit, meetingDate, isOnline,location
+	 */
+	public Club updateClub(Club toClub, MultipartFile bannerImage) {
+		Club club = findClubById(toClub.getClubId());
+
+		// TODO : 수정제한 항목에 대한 조건 검사를 해야합니다.
+
+		// TODO : banner image에 대한 처리 로직이 필요합니다.
+
+		beanUtils.copyNonNullProperties(toClub, club);
+
+		return clubRepository.save(club);
+	}
+
+	public Club cancelClub(Long clubId) {
+		Club club = findClubById(clubId);
+
+		club.setClubStatus(Club.ClubStatus.CLUB_CANCEL);
+
+		return clubRepository.save(club);
+	}
+
+	public Club findClubById(Long clubId) {
+		Optional<Club> optionalClub = clubRepository.findById(clubId);
+		Club club = optionalClub.orElseThrow(() -> new BusinessLogicException(ExceptionCode.CLUB_NOT_FOUND));
+
+		return club;
 	}
 }

--- a/azit-back/src/main/java/com/codestates/azitserver/global/validator/NotSpace.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/global/validator/NotSpace.java
@@ -1,0 +1,20 @@
+package com.codestates.azitserver.global.validator;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {NotSpaceValidator.class})
+public @interface NotSpace {
+	String message() default "must not be empty space.";
+
+	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
+}

--- a/azit-back/src/main/java/com/codestates/azitserver/global/validator/NotSpaceValidator.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/global/validator/NotSpaceValidator.java
@@ -1,0 +1,18 @@
+package com.codestates.azitserver.global.validator;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+import org.springframework.util.StringUtils;
+
+public class NotSpaceValidator implements ConstraintValidator<NotSpace, String> {
+	@Override
+	public void initialize(NotSpace constraintAnnotation) {
+		ConstraintValidator.super.initialize(constraintAnnotation);
+	}
+
+	@Override
+	public boolean isValid(String value, ConstraintValidatorContext context) {
+		return value == null || StringUtils.hasText(value);
+	}
+}

--- a/azit-back/src/test/java/com/codestates/azitserver/domain/club/controller/ClubControllerTest.java
+++ b/azit-back/src/test/java/com/codestates/azitserver/domain/club/controller/ClubControllerTest.java
@@ -3,7 +3,6 @@ package com.codestates.azitserver.domain.club.controller;
 import static com.codestates.azitserver.global.utils.AsciiDocsUtils.*;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.restdocs.headers.HeaderDocumentation.*;
-import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -22,8 +21,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.restdocs.payload.ResponseFieldsSnippet;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -53,33 +50,30 @@ class ClubControllerTest implements ClubControllerTestHelper {
 
 	Club club;
 	ClubDto.Post post;
+	ClubDto.Patch patch;
 	ClubDto.Response response;
+	MockMultipartFile image;
 
 	@BeforeEach
 	void beforeEach() {
 		// Make stub data
 		club = ClubStubData.getDefaultClub();
 		post = ClubStubData.getClubDtoPost();
+		patch = ClubStubData.getClubDtoPatch();
 		response = ClubStubData.getClubDtoResponse();
-	}
-
-	@Test
-	void postClub() throws Exception {
-		// given
-		MockMultipartFile image = new MockMultipartFile(
+		image = new MockMultipartFile(
 			"image",
 			"hello-world.png",
 			MediaType.MULTIPART_FORM_DATA_VALUE,
 			"".getBytes()
 		);
+	}
 
+	@Test
+	void postClub() throws Exception {
+		// given
 		String content = objectMapper.writeValueAsString(post);
-		MockMultipartFile data = new MockMultipartFile(
-			"data",
-			"",
-			MediaType.APPLICATION_JSON_VALUE,
-			content.getBytes()
-		);
+		MockMultipartFile data = ClubStubData.getMultipartJsonData(content);
 
 		given(mapper.clubDtoPostToClubEntity(Mockito.any(ClubDto.Post.class))).willReturn(club);
 		given(clubService.createClub(Mockito.any(Club.class), any())).willReturn(club);
@@ -99,44 +93,70 @@ class ClubControllerTest implements ClubControllerTestHelper {
 					requestParts(List.of(
 						partWithName("data").description("data"),
 						partWithName("image").description("image").optional())),
-					requestPartFields("data",
-						fieldWithPath("clubName").type(JsonFieldType.STRING).description("아지트 이름"),
-						fieldWithPath("clubInfo").type(JsonFieldType.STRING).description("아지트 소개"),
-						fieldWithPath("memberLimit").type(JsonFieldType.NUMBER).description("참가 인원 제한"),
-						fieldWithPath("fee").type(JsonFieldType.NUMBER).description("참가비"),
-						fieldWithPath("joinMethod").type(JsonFieldType.STRING).description("참가 방식 [ APPROVAL | FIRST_COME ]"),
-						fieldWithPath("birthYearMin").type(JsonFieldType.STRING).description("최소 년생 제한"),
-						fieldWithPath("birthYearMax").type(JsonFieldType.STRING).description("최대 년생 제한"),
-						fieldWithPath("genderRestriction").type(JsonFieldType.STRING).description("성별 제한 [ MALE_ONLY | FEMALE_ONLY | ALL ]"),
-						fieldWithPath("meetingDate").type(JsonFieldType.STRING).description("날짜 및 시간"),
-						fieldWithPath("isOnline").type(JsonFieldType.BOOLEAN).description("만남 타입 [ true : 온라인 | false : 오프라인 ]"),
-						fieldWithPath("location").type(JsonFieldType.STRING).description("오프라인 만남 장소"),
-						fieldWithPath("joinQuestion").type(JsonFieldType.STRING).description("참가 신청 질문")
-						),
-					getSingleResponseSnippet()
+					ClubFieldDescriptor.getPostRequestPartFieldsSnippet(),
+					ClubFieldDescriptor.getSingleResponseSnippet()
 				)
 			);
-
 	}
 
-	public static ResponseFieldsSnippet getSingleResponseSnippet() {
-		return responseFields(
-			fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터")
-		).andWithPrefix("data.",
-			fieldWithPath("clubId").type(JsonFieldType.NUMBER).description("아지트 고유 식별자"),
-			fieldWithPath("clubName").type(JsonFieldType.STRING).description("아지트 이름"),
-			fieldWithPath("clubInfo").type(JsonFieldType.STRING).description("아지트 소개"),
-			fieldWithPath("memberLimit").type(JsonFieldType.NUMBER).description("참가 인원 제한"),
-			fieldWithPath("fee").type(JsonFieldType.NUMBER).description("참가비"),
-			fieldWithPath("joinMethod").type(JsonFieldType.STRING).description("참가 방식 [ APPROVAL | FIRST_COME ]"),
-			fieldWithPath("birthYearMin").type(JsonFieldType.STRING).description("최소 년생 제한"),
-			fieldWithPath("birthYearMax").type(JsonFieldType.STRING).description("최대 년생 제한"),
-			fieldWithPath("genderRestriction").type(JsonFieldType.STRING).description("성별 제한 [ MALE_ONLY | FEMALE_ONLY | ALL ]"),
-			fieldWithPath("meetingDate").type(JsonFieldType.STRING).description("날짜 및 시간"),
-			fieldWithPath("isOnline").type(JsonFieldType.BOOLEAN).description("만남 타입 [ true : 온라인 | false : 오프라인 ]"),
-			fieldWithPath("location").type(JsonFieldType.STRING).description("오프라인 만남 장소"),
-			fieldWithPath("joinQuestion").type(JsonFieldType.STRING).description("참가 신청 질문"),
-			fieldWithPath("clubStatus").type(JsonFieldType.STRING).description("아지트 활성화 상태 [ CLUB_ACTIVE | CLUB_CANCEL ]")
-		);
+	@Test
+	void patchClub() throws Exception {
+		// given
+		Long clubId = 1L;
+		patch.setClubId(clubId);
+		String content = objectMapper.writeValueAsString(patch);
+		MockMultipartFile data = ClubStubData.getMultipartJsonData(content);
+
+		given(mapper.clubDtoPatchToClubEntity(Mockito.any(ClubDto.Patch.class))).willReturn(club);
+		given(clubService.updateClub(Mockito.any(Club.class), any())).willReturn(club);
+		given(mapper.clubToClubDtoResponse(Mockito.any(Club.class))).willReturn(response);
+
+		// when
+		ResultActions actions = mockMvc.perform(patchMultipartRequestBuilder(getClubUri(), clubId, image, data)
+			.header("Authorization", "Required JWT access token"));
+
+		// then
+		actions.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.clubId").value(1))
+			.andDo(getDefaultDocument(
+					"patch-club",
+					requestHeaders(headerWithName("Authorization").description("Jwt Access Token")),
+					pathParameters(List.of(
+						parameterWithName("club-id").description("아지트 고유 식별자"))),
+					requestParts(List.of(
+						partWithName("data").description("data"),
+						partWithName("image").description("image").optional())),
+					ClubFieldDescriptor.getPatchRequestPartFieldsSnippet(),
+					ClubFieldDescriptor.getSingleResponseSnippet()
+				)
+			);
+	}
+
+	@Test
+	void deleteClub() throws Exception {
+		// given
+		long clubId = 1L;
+		response.setClubStatus(Club.ClubStatus.CLUB_CANCEL);
+		given(clubService.cancelClub(Mockito.anyLong())).willReturn(club);
+		given(mapper.clubToClubDtoResponse(any(Club.class))).willReturn(response);
+
+		// when
+		ResultActions actions = mockMvc.perform(deleteRequestBuilder(getClubUri(), clubId)
+			.header("Authorization", "Required JWT access token"));
+
+		// then
+		actions.andDo(print())
+			.andExpect(status().isAccepted())
+			.andExpect(jsonPath("$.data.clubId").value(1))
+			.andExpect(jsonPath("$.data.clubStatus").value("CLUB_CANCEL"))
+			.andDo(getDefaultDocument(
+					"delete-club",
+					requestHeaders(headerWithName("Authorization").description("Jwt Access Token")),
+					pathParameters(List.of(
+						parameterWithName("club-id").description("아지트 고유 식별자"))),
+					ClubFieldDescriptor.getSingleResponseSnippet()
+				)
+			);
 	}
 }

--- a/azit-back/src/test/java/com/codestates/azitserver/domain/club/controller/ClubControllerTestHelper.java
+++ b/azit-back/src/test/java/com/codestates/azitserver/domain/club/controller/ClubControllerTestHelper.java
@@ -5,7 +5,13 @@ import com.codestates.azitserver.global.utils.ControllerTestHelper;
 public interface ClubControllerTestHelper extends ControllerTestHelper {
 	String CLUB_URL = "/api/clubs";
 
+	String CLUB_RESOURCE_URI = "/{club-id}";
+
 	default String getClubUrl() {
 		return CLUB_URL;
+	}
+
+	default String getClubUri() {
+		return CLUB_URL + CLUB_RESOURCE_URI;
 	}
 }

--- a/azit-back/src/test/java/com/codestates/azitserver/domain/club/controller/ClubFieldDescriptor.java
+++ b/azit-back/src/test/java/com/codestates/azitserver/domain/club/controller/ClubFieldDescriptor.java
@@ -1,0 +1,72 @@
+package com.codestates.azitserver.domain.club.controller;
+
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.payload.RequestPartFieldsSnippet;
+import org.springframework.restdocs.payload.ResponseFieldsSnippet;
+
+public class ClubFieldDescriptor {
+	public static RequestPartFieldsSnippet getPostRequestPartFieldsSnippet() {
+		return requestPartFields("data",
+			fieldWithPath("clubName").type(JsonFieldType.STRING).description("아지트 이름"),
+			fieldWithPath("clubInfo").type(JsonFieldType.STRING).description("아지트 소개"),
+			fieldWithPath("memberLimit").type(JsonFieldType.NUMBER).description("참가 인원 제한"),
+			fieldWithPath("fee").type(JsonFieldType.NUMBER).description("참가비"),
+			fieldWithPath("joinMethod").type(JsonFieldType.STRING)
+				.description("참가 방식 [ APPROVAL | FIRST_COME ]"),
+			fieldWithPath("birthYearMin").type(JsonFieldType.STRING).description("최소 년생 제한"),
+			fieldWithPath("birthYearMax").type(JsonFieldType.STRING).description("최대 년생 제한"),
+			fieldWithPath("genderRestriction").type(JsonFieldType.STRING)
+				.description("성별 제한 [ MALE_ONLY | FEMALE_ONLY | ALL ]"),
+			fieldWithPath("meetingDate").type(JsonFieldType.STRING).description("날짜 및 시간"),
+			fieldWithPath("isOnline").type(JsonFieldType.BOOLEAN)
+				.description("만남 타입 [ true : 온라인 | false : 오프라인 ]"),
+			fieldWithPath("location").type(JsonFieldType.STRING).description("오프라인 만남 장소"),
+			fieldWithPath("joinQuestion").type(JsonFieldType.STRING).description("참가 신청 질문")
+		);
+	}
+
+	public static RequestPartFieldsSnippet getPatchRequestPartFieldsSnippet() {
+		return requestPartFields("data",
+			fieldWithPath("clubId").type(JsonFieldType.NUMBER).description("아지트 고유 식별자").optional(),
+			fieldWithPath("clubName").type(JsonFieldType.STRING).description("아지트 이름").optional(),
+			fieldWithPath("clubInfo").type(JsonFieldType.STRING).description("아지트 소개").optional(),
+			fieldWithPath("memberLimit").type(JsonFieldType.NUMBER).description("참가 인원 제한").optional(),
+			fieldWithPath("fee").type(JsonFieldType.NUMBER).description("참가비").optional(),
+			fieldWithPath("birthYearMin").type(JsonFieldType.STRING).description("최소 년생 제한").optional(),
+			fieldWithPath("birthYearMax").type(JsonFieldType.STRING).description("최대 년생 제한").optional(),
+			fieldWithPath("genderRestriction").type(JsonFieldType.STRING)
+				.description("성별 제한 [ MALE_ONLY | FEMALE_ONLY | ALL ]")
+				.optional(),
+			fieldWithPath("meetingDate").type(JsonFieldType.STRING).description("날짜 및 시간").optional(),
+			fieldWithPath("isOnline").type(JsonFieldType.BOOLEAN)
+				.description("만남 타입 [ true : 온라인 | false : 오프라인 ]")
+				.optional(),
+			fieldWithPath("location").type(JsonFieldType.STRING).description("오프라인 만남 장소").optional()
+		);
+	}
+
+	public static ResponseFieldsSnippet getSingleResponseSnippet() {
+		return responseFields(
+			fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터")
+		).andWithPrefix("data.",
+			fieldWithPath("clubId").type(JsonFieldType.NUMBER).description("아지트 고유 식별자"),
+			fieldWithPath("clubName").type(JsonFieldType.STRING).description("아지트 이름"),
+			fieldWithPath("clubInfo").type(JsonFieldType.STRING).description("아지트 소개"),
+			fieldWithPath("memberLimit").type(JsonFieldType.NUMBER).description("참가 인원 제한"),
+			fieldWithPath("fee").type(JsonFieldType.NUMBER).description("참가비"),
+			fieldWithPath("joinMethod").type(JsonFieldType.STRING).description("참가 방식 [ APPROVAL | FIRST_COME ]"),
+			fieldWithPath("birthYearMin").type(JsonFieldType.STRING).description("최소 년생 제한"),
+			fieldWithPath("birthYearMax").type(JsonFieldType.STRING).description("최대 년생 제한"),
+			fieldWithPath("genderRestriction").type(JsonFieldType.STRING)
+				.description("성별 제한 [ MALE_ONLY | FEMALE_ONLY | ALL ]"),
+			fieldWithPath("meetingDate").type(JsonFieldType.STRING).description("날짜 및 시간"),
+			fieldWithPath("isOnline").type(JsonFieldType.BOOLEAN).description("만남 타입 [ true : 온라인 | false : 오프라인 ]"),
+			fieldWithPath("location").type(JsonFieldType.STRING).description("오프라인 만남 장소"),
+			fieldWithPath("joinQuestion").type(JsonFieldType.STRING).description("참가 신청 질문"),
+			fieldWithPath("clubStatus").type(JsonFieldType.STRING)
+				.description("아지트 활성화 상태 [ CLUB_ACTIVE | CLUB_CANCEL ]")
+		);
+	}
+}

--- a/azit-back/src/test/java/com/codestates/azitserver/domain/stub/ClubStubData.java
+++ b/azit-back/src/test/java/com/codestates/azitserver/domain/stub/ClubStubData.java
@@ -2,6 +2,9 @@ package com.codestates.azitserver.domain.stub;
 
 import java.time.LocalDateTime;
 
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+
 import com.codestates.azitserver.domain.club.dto.ClubDto;
 import com.codestates.azitserver.domain.club.entity.Club;
 
@@ -29,6 +32,7 @@ public class ClubStubData {
 
 	public static ClubDto.Post getClubDtoPost() {
 		ClubDto.Post post = new ClubDto.Post();
+
 		post.setClubName("재밌는 아지트");
 		post.setClubInfo("재밌는 아지트입니다.");
 		post.setMemberLimit(4);
@@ -43,6 +47,23 @@ public class ClubStubData {
 		post.setJoinQuestion("재밌는 아지트 맞을까요?");
 
 		return post;
+	}
+
+	public static ClubDto.Patch getClubDtoPatch() {
+		ClubDto.Patch patch = new ClubDto.Patch();
+
+		patch.setClubName("재밌는 아지트");
+		patch.setClubInfo("재밌는 아지트입니다.");
+		patch.setMemberLimit(4);
+		patch.setFee(10000);
+		patch.setBirthYearMin("1990");
+		patch.setBirthYearMax("2000");
+		patch.setGenderRestriction(Club.GenderRestriction.ALL);
+		patch.setMeetingDate(LocalDateTime.now().plusDays(1));
+		patch.setIsOnline(false);
+		patch.setLocation("서울시 송파구");
+
+		return patch;
 	}
 
 	public static ClubDto.Response getClubDtoResponse() {
@@ -64,5 +85,14 @@ public class ClubStubData {
 		response.setClubStatus(Club.ClubStatus.CLUB_ACTIVE);
 
 		return response;
+	}
+
+	public static MockMultipartFile getMultipartJsonData(String content) {
+		return new MockMultipartFile(
+			"data",
+			"",
+			MediaType.APPLICATION_JSON_VALUE,
+			content.getBytes()
+		);
 	}
 }

--- a/azit-back/src/test/java/com/codestates/azitserver/global/utils/ControllerTestHelper.java
+++ b/azit-back/src/test/java/com/codestates/azitserver/global/utils/ControllerTestHelper.java
@@ -2,15 +2,55 @@ package com.codestates.azitserver.global.utils;
 
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 
+import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
 public interface ControllerTestHelper {
-	default MockHttpServletRequestBuilder postMultipartRequestBuilder(String url, MockMultipartFile file1, MockMultipartFile file2) {
+	// TODO : MockMultipartFile을 가변인자로 받을 수 있는 방법 고민해보기
+	default MockHttpServletRequestBuilder postMultipartRequestBuilder(String url, MockMultipartFile file1,
+		MockMultipartFile file2) {
 		return multipart(url)
 			.file(file1)
 			.file(file2)
 			.accept(MediaType.APPLICATION_JSON);
+	}
+
+	// form 형식의 요청은 GET, POST만 가능하다?! https://mangkyu.tistory.com/218
+	default MockHttpServletRequestBuilder patchMultipartRequestBuilder(String url, Long resourceId,
+		MockMultipartFile file1, MockMultipartFile file2) {
+		return multipart(url, resourceId)
+			.file(file1)
+			.file(file2)
+			.accept(MediaType.APPLICATION_JSON)
+			.with(req -> {
+				req.setMethod(HttpMethod.PATCH.name());
+				return req;
+			});
+	}
+
+	// TODO : 작성 예정
+	default MockHttpServletRequestBuilder postRequestBuilder(String url) {
+		return null;
+	}
+
+	// TODO : 작성 예정
+	default MockHttpServletRequestBuilder getRequestBuilder(String url) {
+		return null;
+	}
+
+	// TODO : 작성 예정
+	default MockHttpServletRequestBuilder getRequestBuilder(String url, long resourceId) {
+		return null;
+	}
+
+	// TODO : 작성 예정
+	default MockHttpServletRequestBuilder patchRequestBuilder(String url, long resourceId) {
+		return null;
+	}
+
+	default MockHttpServletRequestBuilder deleteRequestBuilder(String url, long resourceId) {
+		return delete(url, resourceId);
 	}
 }


### PR DESCRIPTION
## 개요
issue [#16 ] 중
아지트 정보 수정 및 예약 취소 api 구현하였습니다.

## 주요 작업사항
- patch, delete 각각에 맞는 controller, dto, service 등 구현
- 각 컨트롤러에 대한 테스트코드 작성
- api 문서 작성

## 기능 외 변경사항(개발 범위 외 수정된 사항 등)

## 기타
- 공유된 이슈처럼 form 형식의 요청이 POST, GET밖에 요청을 못해서 해당 부분은 클라이언트에서 요청을 보낼수 있는지 유무에 따라 api가 변경될 수 있습니다.
