### PR TITLE
[Club/image]

### DIFF
--- a/azit-back/src/docs/asciidoc/index.adoc
+++ b/azit-back/src/docs/asciidoc/index.adoc
@@ -56,9 +56,6 @@ include::{snippets}/get-all-clubs/curl-request.adoc[]
 .http-request
 include::{snippets}/get-all-clubs/http-request.adoc[]
 
-.request-headers
-include::{snippets}/get-all-clubs/request-headers.adoc[]
-
 .request-parameters
 include::{snippets}/get-all-clubs/request-parameters.adoc[]
 
@@ -79,9 +76,6 @@ include::{snippets}/get-club-by-club-id/http-request.adoc[]
 .path-parameters
 include::{snippets}/get-club-by-club-id/path-parameters.adoc[]
 
-.request-headers
-include::{snippets}/get-club-by-club-id/request-headers.adoc[]
-
 .http-response
 include::{snippets}/get-club-by-club-id/http-response.adoc[]
 
@@ -95,9 +89,6 @@ include::{snippets}/get-club-by-category-id/curl-request.adoc[]
 
 .http-request
 include::{snippets}/get-club-by-category-id/http-request.adoc[]
-
-.request-headers
-include::{snippets}/get-club-by-category-id/request-headers.adoc[]
 
 .request-parameters
 include::{snippets}/get-club-by-category-id/request-parameters.adoc[]
@@ -115,9 +106,6 @@ include::{snippets}/get-club-by-meeting-date/curl-request.adoc[]
 
 .http-request
 include::{snippets}/get-club-by-meeting-date/http-request.adoc[]
-
-.request-headers
-include::{snippets}/get-club-by-meeting-date/request-headers.adoc[]
 
 .request-parameters
 include::{snippets}/get-club-by-meeting-date/request-parameters.adoc[]
@@ -201,9 +189,6 @@ include::{snippets}/search-club/curl-request.adoc[]
 
 .http-request
 include::{snippets}/search-club/http-request.adoc[]
-
-.request-headers
-include::{snippets}/search-club/request-headers.adoc[]
 
 .request-parameters
 include::{snippets}/search-club/request-parameters.adoc[]

--- a/azit-back/src/docs/asciidoc/index.adoc
+++ b/azit-back/src/docs/asciidoc/index.adoc
@@ -131,28 +131,48 @@ include::{snippets}/get-club-by-meeting-date/response-fields.adoc[]
 === 아지트 정보 수정
 
 .curl-request
-include::{snippets}/patch-club/curl-request.adoc[]
+include::{snippets}/patch-club-data/curl-request.adoc[]
 
 .http-request
-include::{snippets}/patch-club/http-request.adoc[]
+include::{snippets}/patch-club-data/http-request.adoc[]
 
 .path-parameters
-include::{snippets}/patch-club/path-parameters.adoc[]
+include::{snippets}/patch-club-data/path-parameters.adoc[]
 
 .request-headers
-include::{snippets}/patch-club/request-headers.adoc[]
+include::{snippets}/patch-club-data/request-headers.adoc[]
 
-.request-parts
-include::{snippets}/patch-club/request-parts.adoc[]
-
-.request-part-data-fields
-include::{snippets}/patch-club/request-part-data-fields.adoc[]
+.request-fields
+include::{snippets}/patch-club-data/request-fields.adoc[]
 
 .http-response
-include::{snippets}/patch-club/http-response.adoc[]
+include::{snippets}/patch-club-data/http-response.adoc[]
 
 .response-fields
-include::{snippets}/patch-club/response-fields.adoc[]
+include::{snippets}/patch-club-data/response-fields.adoc[]
+
+=== 아지트 배너 이미지 수정
+
+.curl-request
+include::{snippets}/patch-club-image/curl-request.adoc[]
+
+.http-request
+include::{snippets}/patch-club-image/http-request.adoc[]
+
+.path-parameters
+include::{snippets}/patch-club-image/path-parameters.adoc[]
+
+.request-headers
+include::{snippets}/patch-club-image/request-headers.adoc[]
+
+.request-parts
+include::{snippets}/patch-club-image/request-parts.adoc[]
+
+.http-response
+include::{snippets}/patch-club-image/http-response.adoc[]
+
+.response-fields
+include::{snippets}/patch-club-image/response-fields.adoc[]
 
 === 아지트 예약 취소
 

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/club/controller/ClubController.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/club/controller/ClubController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -56,13 +57,27 @@ public class ClubController {
 
 	}
 
+	/**
+	 * 아지트 배너 이미지 변경
+	 * @param clubId 아지트 고유 식별자
+	 * @param bannerImage 바꾸려는 이미지 정보
+	 * @return 업데이트 된 아지트 정보를 리턴합니다.
+	 */
+	@PostMapping(value = "/{club-id}", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+	public ResponseEntity<?> postClubImage(@Positive @PathVariable("club-id") Long clubId,
+		@RequestPart(name = "image", required = false) MultipartFile bannerImage) {
+		Club club = clubService.updateClubImage(clubId, bannerImage);
+		ClubDto.Response response = mapper.clubToClubDtoResponse(club);
+
+		return new ResponseEntity<>(new SingleResponseDto<>(response), HttpStatus.OK);
+	}
+
 	@PatchMapping("/{club-id}")
 	public ResponseEntity<?> patchClub(@Positive @PathVariable("club-id") Long clubId,
-		@Valid @RequestPart(name = "data") ClubDto.Patch patch,
-		@RequestPart(name = "image", required = false) MultipartFile bannerImage) {
+		@Valid @RequestBody ClubDto.Patch patch) {
 		patch.setClubId(clubId);
 		Club toClub = mapper.clubDtoPatchToClubEntity(patch);
-		Club club = clubService.updateClub(toClub, bannerImage);
+		Club club = clubService.updateClub(toClub);
 		ClubDto.Response response = mapper.clubToClubDtoResponse(club);
 
 		return new ResponseEntity<>(new SingleResponseDto<>(response), HttpStatus.OK);

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/club/service/ClubService.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/club/service/ClubService.java
@@ -36,16 +36,21 @@ public class ClubService {
 	/**
 	 * - 수정 제한 항목(신청자 또는 참가자 있을시) : clubName, memberLimit, meetingDate, isOnline,location
 	 */
-	public Club updateClub(Club toClub, MultipartFile bannerImage) {
+	public Club updateClub(Club toClub) {
 		Club club = findClubById(toClub.getClubId());
 
 		// TODO : 수정제한 항목에 대한 조건 검사를 해야합니다.
 
-		// TODO : banner image에 대한 처리 로직이 필요합니다.
-
 		beanUtils.copyNonNullProperties(toClub, club);
 
 		return clubRepository.save(club);
+	}
+
+	public Club updateClubImage(Long clubId, MultipartFile bannerImage) {
+
+		// TODO : banner image에 대한 처리 로직이 필요합니다.
+
+		return null;
 	}
 
 	public Club cancelClub(Long clubId) {

--- a/azit-back/src/main/java/com/codestates/azitserver/global/config/SecurityConfig.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/global/config/SecurityConfig.java
@@ -58,38 +58,13 @@ public class SecurityConfig {
 				/*======h2, docs======*/
 				.antMatchers(HttpMethod.GET, "/h2/**").permitAll() // h2
 				.antMatchers("/docs/index.html").permitAll() // docs
-				/*======auth======*/
-				.antMatchers(HttpMethod.POST, "/auth/login").permitAll() // 로그인 누구나 가능
-				.antMatchers(HttpMethod.POST, "/auth/logout").hasRole("USER") // 로그아웃 유저 가능
-				.antMatchers(HttpMethod.POST, "/**/passwords").permitAll() // 비밀번호 찾기 유저 가능
-				.antMatchers(HttpMethod.POST, "/**/passwords/matchers").hasRole("USER") // 비밀번호 인증 유저 가능
-				.antMatchers(HttpMethod.PATCH, "/**/passwords").hasAnyRole("USER", "ADMIN") // 비밀번호 변경 유저 가능(랜덤 비밀번호 발생 시 admin 권한 필요)
-				/*======member======*/
-				.antMatchers(HttpMethod.POST, "/members").permitAll() // 회원 생성 누구나 가능
-				.antMatchers(HttpMethod.PATCH, "/members/**").hasRole("USER") // 회원 수정 유저 가능
-				.antMatchers(HttpMethod.GET, "/members").hasRole("ADMIN") // 전체 회원 조회 관리자 가능
-				.antMatchers(HttpMethod.GET, "/members/**").hasAnyRole("USER", "ADMIN") // 개별 회원 조회 유저, 관리자 가능
-				.antMatchers(HttpMethod.DELETE, "/members/**").hasAnyRole("USER", "ADMIN") // 회원 탈퇴 유저, 관리자 가능
-				.antMatchers(HttpMethod.POST, "/members/follows/**").hasRole("USER") // 팔로우 유저 가능
-				.antMatchers(HttpMethod.POST, "/members/reports/**").hasRole("USER") // 신고 유저 가능
-				.antMatchers(HttpMethod.POST, "/members/blocks/**").hasRole("USER") // 차단 유저 가능
-				/*======club======*/
-				.antMatchers(HttpMethod.POST, "/clubs").hasRole("USER") // 아지트 생성 유저 가능
-				.antMatchers(HttpMethod.GET, "/clubs/recommend/**").hasRole("USER") // 추천 아지트 조회 유저 가능
-				.antMatchers(HttpMethod.GET, "/clubs/members/**").hasRole("USER") // 특정 유저 아지트 조회 유저 가능
-				.antMatchers(HttpMethod.GET, "/clubs/**").permitAll() // 아지트 조회, 검색 누구나 가능
-				.antMatchers(HttpMethod.PATCH, "/clubs/**").hasRole("USER") // 아지트 수정 호스트 가능
-				.antMatchers(HttpMethod.DELETE, "/clubs/**").hasRole("USER") // 아지트 삭제 호스트 가능
-				.antMatchers(HttpMethod.POST, "/clubs/reports/**").hasRole("USER") // 아지트 신고 유저 가능
-				.antMatchers(HttpMethod.POST, "/**/signups").hasRole("USER") // 아지트 참여 신청 유저 가능
-				.antMatchers(HttpMethod.POST, "/**/signups/**").hasRole("USER") // 아지트 참여 승인/거부 호스트 가능
-				.antMatchers(HttpMethod.POST, "/**/kicks/**").hasRole("USER") // 아지트 강퇴 호스트 가능
-				/*======review======*/
-				.antMatchers(HttpMethod.POST, "/reviews").hasRole("USER") // 리뷰 유저 가능
-				.antMatchers(HttpMethod.PATCH, "/reviews/**").hasRole("USER") // 리뷰 상태변경 유저 가능
-				.antMatchers(HttpMethod.GET, "/reviews").hasRole("USER") // 리뷰 전체 조회 유저 가능
 
-				.anyRequest().permitAll()
+				/*======아래 도메인에 맞는 권한 설정을 부여해야합니다.======*/
+				.antMatchers(HttpMethod.GET, "api/clubs/recommend/**").authenticated()  // 회원 추천 아지트 조회
+				.antMatchers(HttpMethod.GET, "api/clubs/members/**").authenticated()  // 특정 회원이 참여한 아지트 조회
+				.antMatchers(HttpMethod.GET, "api/clubs/**").permitAll()  // 그 외 아지트 조회
+
+				.anyRequest().permitAll()  // TODO : 개발하기 편하게 임시로 .permitAll() 설정 -> 나중에 .authenticated() 바꾸기
 			);
 
 		return http.build();

--- a/azit-back/src/test/java/com/codestates/azitserver/domain/club/controller/ClubControllerTest.java
+++ b/azit-back/src/test/java/com/codestates/azitserver/domain/club/controller/ClubControllerTest.java
@@ -106,19 +106,15 @@ class ClubControllerTest implements ClubControllerTestHelper {
 	}
 
 	@Test
-	void patchClub() throws Exception {
+	void postClubImage() throws Exception {
 		// given
-		Long clubId = 1L;
-		patch.setClubId(clubId);
-		String content = objectMapper.writeValueAsString(patch);
-		MockMultipartFile data = ClubStubData.getMultipartJsonData(content);
+		long clubId = 1L;
 
-		given(mapper.clubDtoPatchToClubEntity(Mockito.any(ClubDto.Patch.class))).willReturn(club);
-		given(clubService.updateClub(Mockito.any(Club.class), any())).willReturn(club);
+		given(clubService.updateClubImage(Mockito.anyLong(), Mockito.any())).willReturn(club);
 		given(mapper.clubToClubDtoResponse(Mockito.any(Club.class))).willReturn(response);
 
 		// when
-		ResultActions actions = mockMvc.perform(patchMultipartRequestBuilder(getClubUri(), clubId, image, data)
+		ResultActions actions = mockMvc.perform(postMultipartRequestBuilder(getClubUri(), clubId, image)
 			.header("Authorization", "Required JWT access token"));
 
 		// then
@@ -126,14 +122,41 @@ class ClubControllerTest implements ClubControllerTestHelper {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.clubId").value(1))
 			.andDo(getDefaultDocument(
-					"patch-club",
+					"patch-club-image",
 					requestHeaders(headerWithName("Authorization").description("Jwt Access Token")),
 					pathParameters(List.of(
 						parameterWithName("club-id").description("아지트 고유 식별자"))),
-					requestParts(List.of(
-						partWithName("data").description("data"),
-						partWithName("image").description("image").optional())),
-					ClubFieldDescriptor.getPatchRequestPartFieldsSnippet(),
+					requestParts(List.of(partWithName("image").description("image"))),
+					ClubFieldDescriptor.getSingleResponseSnippet()
+				)
+			);
+	}
+
+	@Test
+	void patchClub() throws Exception {
+		// given
+		long clubId = 1L;
+		patch.setClubId(clubId);
+		String content = objectMapper.writeValueAsString(patch);
+
+		given(mapper.clubDtoPatchToClubEntity(Mockito.any(ClubDto.Patch.class))).willReturn(club);
+		given(clubService.updateClub(Mockito.any(Club.class))).willReturn(club);
+		given(mapper.clubToClubDtoResponse(Mockito.any(Club.class))).willReturn(response);
+
+		// when
+		ResultActions actions = mockMvc.perform(patchRequestBuilder(getClubUri(), clubId, content)
+			.header("Authorization", "Required JWT access token"));
+
+		// then
+		actions.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.clubId").value(1))
+			.andDo(getDefaultDocument(
+					"patch-club-data",
+					requestHeaders(headerWithName("Authorization").description("Jwt Access Token")),
+					pathParameters(List.of(
+						parameterWithName("club-id").description("아지트 고유 식별자"))),
+					ClubFieldDescriptor.getPatchRequestFieldsSnippet(),
 					ClubFieldDescriptor.getSingleResponseSnippet()
 				)
 			);
@@ -177,15 +200,13 @@ class ClubControllerTest implements ClubControllerTestHelper {
 		given(mapper.clubToClubDtoResponse(Mockito.anyList())).willReturn(List.of(response));
 
 		// when
-		ResultActions actions = mockMvc.perform(getRequestBuilder(getClubUrl(), queryParams)
-			.header("Authorization", "Required JWT access token"));
+		ResultActions actions = mockMvc.perform(getRequestBuilder(getClubUrl(), queryParams));
 
 		// then
 		actions.andDo(print())
 			.andExpect(status().isOk())
 			.andDo(getDefaultDocument(
 					"get-all-clubs",
-					requestHeaders(headerWithName("Authorization").description("Jwt Access Token")),
 					requestParameters(
 						List.of(
 							parameterWithName("page").description("Page 번호"),
@@ -205,15 +226,13 @@ class ClubControllerTest implements ClubControllerTestHelper {
 		given(mapper.clubToClubDtoResponse(Mockito.any(Club.class))).willReturn(response);
 
 		// when
-		ResultActions actions = mockMvc.perform(getRequestBuilder(getClubUri(), clubId)
-			.header("Authorization", "Required JWT access token"));
+		ResultActions actions = mockMvc.perform(getRequestBuilder(getClubUri(), clubId));
 
 		// then
 		actions.andDo(print())
 			.andExpect(status().isOk())
 			.andDo(getDefaultDocument(
 					"get-club-by-club-id",
-					requestHeaders(headerWithName("Authorization").description("Jwt Access Token")),
 					pathParameters(List.of(
 						parameterWithName("club-id").description("아지트 고유 식별자"))),
 					ClubFieldDescriptor.getSingleResponseSnippet()
@@ -234,15 +253,13 @@ class ClubControllerTest implements ClubControllerTestHelper {
 		given(mapper.clubToClubDtoResponse(Mockito.anyList())).willReturn(List.of(response));
 
 		// when
-		ResultActions actions = mockMvc.perform(getRequestBuilder(getClubUrl() + "/category", queryParams)
-			.header("Authorization", "Required JWT access token"));
+		ResultActions actions = mockMvc.perform(getRequestBuilder(getClubUrl() + "/category", queryParams));
 
 		// then
 		actions.andDo(print())
 			.andExpect(status().isOk())
 			.andDo(getDefaultDocument(
 					"get-club-by-category-id",
-					requestHeaders(headerWithName("Authorization").description("Jwt Access Token")),
 					requestParameters(
 						List.of(
 							parameterWithName("page").description("Page 번호"),
@@ -268,20 +285,19 @@ class ClubControllerTest implements ClubControllerTestHelper {
 		given(mapper.clubToClubDtoResponse(Mockito.anyList())).willReturn(List.of(response));
 
 		// when
-		ResultActions actions = mockMvc.perform(getRequestBuilder(getClubUrl() + "/date", queryParams)
-			.header("Authorization", "Required JWT access token"));
+		ResultActions actions = mockMvc.perform(getRequestBuilder(getClubUrl() + "/date", queryParams));
 
 		// then
 		actions.andDo(print())
 			.andExpect(status().isOk())
 			.andDo(getDefaultDocument(
 					"get-club-by-meeting-date",
-					requestHeaders(headerWithName("Authorization").description("Jwt Access Token")),
 					requestParameters(
 						List.of(
 							parameterWithName("page").description("Page 번호"),
 							parameterWithName("size").description("Page 크기"),
-							parameterWithName("days").description("오늘(0) 기준으로 며칠 뒤의 날짜").attributes(key("constraints").value("0 ~ 5 사이의 정수"))
+							parameterWithName("days").description("오늘(0) 기준으로 며칠 뒤의 날짜")
+								.attributes(key("constraints").value("0 ~ 5 사이의 정수"))
 						)
 					),
 					ClubFieldDescriptor.getMultiResponseSnippet()
@@ -316,20 +332,19 @@ class ClubControllerTest implements ClubControllerTestHelper {
 		given(mapper.clubToClubDtoResponse(Mockito.anyList())).willReturn(List.of(response));
 
 		// when
-		ResultActions actions = mockMvc.perform(getRequestBuilder(getClubUrl() + "/search", queryParams)
-			.header("Authorization", "Required JWT access token"));
+		ResultActions actions = mockMvc.perform(getRequestBuilder(getClubUrl() + "/search", queryParams));
 
 		// then
 		actions.andDo(print())
 			.andExpect(status().isOk())
 			.andDo(getDefaultDocument(
 					"search-club",
-					requestHeaders(headerWithName("Authorization").description("Jwt Access Token")),
 					requestParameters(
 						List.of(
 							parameterWithName("page").description("Page 번호"),
 							parameterWithName("size").description("Page 크기"),
-							parameterWithName("keyword").description("검색어").attributes(key("constraints").value("빈 문자이면 전체 아지트를 리턴합니다."))
+							parameterWithName("keyword").description("검색어")
+								.attributes(key("constraints").value("빈 문자이면 전체 아지트를 리턴합니다."))
 						)
 					),
 					ClubFieldDescriptor.getMultiResponseSnippet()

--- a/azit-back/src/test/java/com/codestates/azitserver/domain/club/controller/ClubFieldDescriptor.java
+++ b/azit-back/src/test/java/com/codestates/azitserver/domain/club/controller/ClubFieldDescriptor.java
@@ -4,6 +4,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.snippet.Attributes.*;
 
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.payload.RequestFieldsSnippet;
 import org.springframework.restdocs.payload.RequestPartFieldsSnippet;
 import org.springframework.restdocs.payload.ResponseFieldsSnippet;
 
@@ -30,8 +31,8 @@ public class ClubFieldDescriptor {
 		);
 	}
 
-	public static RequestPartFieldsSnippet getPatchRequestPartFieldsSnippet() {
-		return requestPartFields("data",
+	public static RequestFieldsSnippet getPatchRequestFieldsSnippet() {
+		return requestFields(
 			fieldWithPath("clubId").type(JsonFieldType.NUMBER).description("아지트 고유 식별자").optional(),
 			fieldWithPath("clubName").type(JsonFieldType.STRING).description("아지트 이름").optional(),
 			fieldWithPath("clubInfo").type(JsonFieldType.STRING).description("아지트 소개").optional(),

--- a/azit-back/src/test/java/com/codestates/azitserver/global/utils/ControllerTestHelper.java
+++ b/azit-back/src/test/java/com/codestates/azitserver/global/utils/ControllerTestHelper.java
@@ -2,7 +2,6 @@ package com.codestates.azitserver.global.utils;
 
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 
-import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -19,16 +18,11 @@ public interface ControllerTestHelper {
 	}
 
 	// form 형식의 요청은 GET, POST만 가능하다?! https://mangkyu.tistory.com/218
-	default MockHttpServletRequestBuilder patchMultipartRequestBuilder(String url, Long resourceId,
-		MockMultipartFile file1, MockMultipartFile file2) {
+	default MockHttpServletRequestBuilder postMultipartRequestBuilder(String url, Long resourceId,
+		MockMultipartFile file) {
 		return multipart(url, resourceId)
-			.file(file1)
-			.file(file2)
-			.accept(MediaType.APPLICATION_JSON)
-			.with(req -> {
-				req.setMethod(HttpMethod.PATCH.name());
-				return req;
-			});
+			.file(file)
+			.accept(MediaType.APPLICATION_JSON);
 	}
 
 	// TODO : 작성 예정
@@ -47,15 +41,16 @@ public interface ControllerTestHelper {
 			.accept(MediaType.APPLICATION_JSON);
 	}
 
-	// TODO : 작성 예정
 	default MockHttpServletRequestBuilder getRequestBuilder(String url, long resourceId) {
 		return get(url, resourceId)
 			.accept(MediaType.APPLICATION_JSON);
 	}
 
-	// TODO : 작성 예정
-	default MockHttpServletRequestBuilder patchRequestBuilder(String url, long resourceId) {
-		return null;
+	default MockHttpServletRequestBuilder patchRequestBuilder(String url, long resourceId, String content) {
+		return patch(url, resourceId)
+			.accept(MediaType.APPLICATION_JSON)
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(content);
 	}
 
 	default MockHttpServletRequestBuilder deleteRequestBuilder(String url, long resourceId) {


### PR DESCRIPTION
## 개요
클라이언트에서 `multipart/form-data`를 `POST` 메서드로밖에 보내질 못해 `PATCH`를 각각 데이터, 이미지를 보내는 2개의 api로 분리했습니다.

## 주요 작업사항
- `PATCH` 컨트롤러 2개로 분리
    - 데이터 수정 : `PATCH` `/api/clubs/{club-id}`
    - 이미지 수정 : `POST` `/api/clubs/{club-id}`
- 각각의 컨트롤러에 대한 테스트 코드 수정
- api 문서 업데이트

## 기능 외 변경사항(개발 범위 외 수정된 사항 등)
- token 인증이 일단락 구현됨에 따라 `securityConfig.java` 내 권한 설정 부분 모두 제거.
- 권한 설정은 각 도메인 담당자가 직접 설정합니다.

## 기타
- 일단 권한 설정은 개발단계이기때문에 따로 설정하지 않으면 permitAll 상태로 되도록 바꿨습니다.(api 테스트에 용이)
- 추후 위 설정은 permitAll -> authenticate로 변경되어야 합니다.
- api 도메인 권한 설정은 언젠가 반드시 이루어져야 합니다.