### PR TITLE
[File] 프로필, 배너 이미지 저장소 구현 및 저장 로직 구현

### DIFF
--- a/azit-back/.gitignore
+++ b/azit-back/.gitignore
@@ -5,7 +5,6 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
-/src/main/resources/static/docs/index.html
 
 ### STS ###
 .apt_generated
@@ -42,5 +41,6 @@ out/
 env.yml
 env.properties
 
-### restdocs ###
+### static files ###
 src/main/resources/static/docs/index.html
+images/

--- a/azit-back/build.gradle
+++ b/azit-back/build.gradle
@@ -36,6 +36,9 @@ dependencies {
 	// sql 쿼리 파라미터에 실제 입력 값을 보여주기 위한 패키지
 	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.8.1'
 
+	// aws s3 file upload
+	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.382'
+
 	// 인증
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation'it.ozimov:embedded-redis:0.7.2'

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/fileInfo/entity/FileInfo.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/fileInfo/entity/FileInfo.java
@@ -1,0 +1,27 @@
+package com.codestates.azitserver.domain.fileInfo.entity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+import com.codestates.azitserver.domain.common.Auditable;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+public class FileInfo extends Auditable {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long fileId;
+
+	@Column(nullable = false, unique = true)
+	private String fileName;
+
+	@Column(nullable = false)
+	private String fileUrl;
+}

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/fileInfo/service/StorageService.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/fileInfo/service/StorageService.java
@@ -1,0 +1,16 @@
+package com.codestates.azitserver.domain.fileInfo.service;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface StorageService {
+	/**
+	 * 스토리지 서비스를 구현하여 원하는 곳에 파일을 저장합니다.
+	 * @param path 파일을 저장할 디렉토리
+	 * @param file 저장할 파일
+	 * @return 파일 정보를 담은 Map을 리턴합니다.
+	 */
+	Map<String, String> upload(Path path, MultipartFile file);
+}

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/fileInfo/service/StorageServiceAwsS3.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/fileInfo/service/StorageServiceAwsS3.java
@@ -1,0 +1,61 @@
+package com.codestates.azitserver.domain.fileInfo.service;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.codestates.azitserver.global.exception.StorageException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@Profile("server")
+@RequiredArgsConstructor
+public class StorageServiceAwsS3 implements StorageService {
+	@Value("${aws.s3.bucket}")
+	private String bucket;
+
+	private final AmazonS3 amazonS3;
+
+	@Override
+	public Map<String, String> upload(Path path, MultipartFile file) {
+		// contents exist
+		if (file.isEmpty()) {
+			throw new StorageException("Failed to store empty file.");
+		}
+
+		// set unique file name
+		String name = UUID.randomUUID().toString();
+		String ext = file.getOriginalFilename().substring(file.getOriginalFilename().lastIndexOf(".") + 1);
+		String filename = name + "." + ext;
+		try {
+			ObjectMetadata objMeta = new ObjectMetadata();
+			objMeta.setContentLength(file.getInputStream().available());
+
+			amazonS3.putObject(bucket + "/" + path, filename, file.getInputStream(), objMeta);
+			log.info("Banner image saved to AWS S3 {} : {}", bucket, path + "/" + filename);
+		} catch (IOException exception) {
+			throw new StorageException("Failed to store file.", exception);
+		}
+
+		// fileUrl(파일 저장 경로)와 fileName(파일명)을 Key로 가지는 map을 리턴합니다.
+		Map<String, String> map = new HashMap<>();
+		map.put("fileUrl", bucket + "/" + path);
+		map.put("fileName", filename);
+
+		return map;
+	}
+}
+
+

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/fileInfo/service/StorageServiceLocal.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/fileInfo/service/StorageServiceLocal.java
@@ -1,0 +1,67 @@
+package com.codestates.azitserver.domain.fileInfo.service;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.codestates.azitserver.global.exception.StorageException;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@Profile("local")
+public class StorageServiceLocal implements StorageService {
+	@Override
+	public Map<String, String> upload(Path path, MultipartFile file) {
+		// contents exist
+		if (file.isEmpty()) {
+			throw new StorageException("Failed to store empty file.");
+		}
+
+		// folder exists
+		try {
+			if (!Files.isDirectory(path)) {
+				Files.createDirectories(path);
+			}
+		} catch (IOException exception) {
+			throw new StorageException("Failed to create save directory.", exception);
+		}
+
+		// set unique file name
+		String name = UUID.randomUUID().toString();
+		String ext = file.getOriginalFilename().substring(file.getOriginalFilename().lastIndexOf(".") + 1);
+		String filename = name + "." + ext;
+		Path dst = path.resolve(filename).normalize().toAbsolutePath();
+		if (Files.exists(dst)) {
+			throw new StorageException("The File already exists.");
+		}
+		if (!dst.getParent().equals(path.toAbsolutePath())) {
+			throw new StorageException("Cannot store file outside current directory.");
+		}
+
+		// copy file
+		try (InputStream inputStream = file.getInputStream()) {
+			Files.copy(inputStream, dst, StandardCopyOption.REPLACE_EXISTING);
+			log.info("Banner image saved to Local : {}", dst);
+		} catch (IOException exception) {
+			throw new StorageException("Failed to store file.", exception);
+		}
+
+		// fileUrl(파일 저장 경로)와 fileName(파일명)을 Key로 가지는 map을 리턴합니다.
+		Map<String, String> map = new HashMap<>();
+		map.put("fileUrl", path.toString());
+		map.put("fileName", filename);
+
+		return map;
+	}
+}

--- a/azit-back/src/main/java/com/codestates/azitserver/global/config/AwsS3Config.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/global/config/AwsS3Config.java
@@ -1,0 +1,36 @@
+package com.codestates.azitserver.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+@Configuration
+@Profile("server")
+public class AwsS3Config {
+	@Value("${aws.credentials.accessKey}")
+	private String accessKey;
+
+	@Value("${aws.credentials.secretKey}")
+	private String secretKey;
+
+	@Value("${aws.region}")
+	private String region;
+
+	// aws S3 client 생성
+	@Bean
+	public AmazonS3 createS3Client() {
+		AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+		return AmazonS3ClientBuilder
+			.standard()
+			.withCredentials(new AWSStaticCredentialsProvider(credentials))
+			.withRegion(region)
+			.build();
+	}
+}

--- a/azit-back/src/main/java/com/codestates/azitserver/global/exception/StorageException.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/global/exception/StorageException.java
@@ -1,0 +1,11 @@
+package com.codestates.azitserver.global.exception;
+
+public class StorageException extends RuntimeException {
+	public StorageException(String message) {
+		super(message);
+	}
+
+	public StorageException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/azit-back/src/main/resources/application-server.yml
+++ b/azit-back/src/main/resources/application-server.yml
@@ -13,3 +13,12 @@ spring:
 logging:
   level:
     root: WARN
+
+# S3 Cloud
+aws:
+  credentials:
+    accessKey: ${AWS_ACCESS_KEY_SERVER}       # AWS IAM AccessKey
+    secretKey: ${AWS_SECRET_ACCESS_KEY_SERVER}   # AWS IAM SecretKey
+  s3:
+    bucket: azit-server-s3
+  region: ap-northeast-2

--- a/azit-back/src/main/resources/application.yml
+++ b/azit-back/src/main/resources/application.yml
@@ -7,7 +7,10 @@ spring:
     init:
       encoding: UTF-8  # 한글 깨짐 해결
       mode: always
-
+  servlet:
+    multipart:  # multipart 설정
+      max-file-size: 8MB
+      max-request-size: 8MB
 server:
   servlet:
     encoding:


### PR DESCRIPTION
## 개요
프로필 이미지, 아지트 배너 이미지를 받아 스토리지에 저장하는 로직을 구현하였습니다.
- `StorageService` 인터페이스를 구현한 `StorageServiceLocal`과 `StorageServiceAwsS3`는 각각 로컬 저장소, s3 저장소에 받은 첨부파일을 처리합니다.
- `StorageService` 의 구현체들은 파일 유효성 검사, 저장 디렉토리 경로 검사 등 여러 검증단계를 거친 후 지정한 디렉토리에 고유 UUID 이를을 가진 파일로 저장이 됩니다.
- 파일 저장이 정상적으로 완료되면 저장된 파일이름, 저장 경로를 담은 Map을 리턴합니다.
- 개발자는 리턴받은 Map에서 정보를 추출하여 FileInfo 엔티티에 정보를 저장후 필요할때마다 저장정보를 바탕으로 첨부파일을 불러옵니다.

## 주요 작업사항
- local에 첨부파일을 저장하는 로직 구현
- aws s3 설정 및 s3에 파일을 저장하는 로직 구현
- FileInfo 엔티티 작성

## 기능 외 변경사항(개발 범위 외 수정된 사항 등)
- aws s3 사용에 따른 의존성 추가
- 불필요한 로컬에 저장되는 이미지는 .gitignore으로 업로드가 안 되게 설정

## 기타
- local에 이미지를 저장하는 것은 `application-local` 환경에서, s3는 `application-server` 환경에서 돌아가도록 빈 설정을 하였습니다.
- ec2 서버에서는 저장경로가 어떻게 될지 궁금하네여...!