### PR TITLE
[Hotfix] 아지트 주소 필드 저장 길이, 파일 업로드시 확장자 확인 

### DIFF
--- a/azit-back/src/main/java/com/codestates/azitserver/domain/club/entity/Club.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/club/entity/Club.java
@@ -70,7 +70,7 @@ public class Club extends Auditable {
 	@Column(name = "IS_ONLINE", nullable = false)
 	private String isOnline;
 
-	@Column(name = "LOCATION", length = 24)
+	@Column(name = "LOCATION")
 	private String location;
 
 	@Column(name = "JOIN_QUESTION", nullable = false, updatable = false, length = 24)

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/fileInfo/service/StorageService.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/fileInfo/service/StorageService.java
@@ -4,6 +4,8 @@ import java.util.Map;
 
 import org.springframework.web.multipart.MultipartFile;
 
+import com.codestates.azitserver.global.exception.StorageException;
+
 public interface StorageService {
 	/**
 	 * 스토리지 서비스를 구현하여 원하는 곳에 파일을 저장합니다.
@@ -12,4 +14,17 @@ public interface StorageService {
 	 * @return 파일 정보를 담은 Map을 리턴합니다.
 	 */
 	Map<String, String> upload(String prefix, MultipartFile file);
+
+	/**
+	 * 인자로 주어진 파일의 content type을 통해 확장자를 구합니다.
+	 * @param file 파일
+	 * @return file의 확장자
+	 */
+	default String getFileExt(MultipartFile file) {
+		if (file.isEmpty()) {
+			throw new StorageException("Failed to store empty file.");
+		}
+
+		return file.getContentType().substring(file.getContentType().lastIndexOf("/") + 1);
+	}
 }

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/fileInfo/service/StorageServiceAwsS3.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/fileInfo/service/StorageServiceAwsS3.java
@@ -36,7 +36,7 @@ public class StorageServiceAwsS3 implements StorageService {
 
 		// set unique file name
 		String name = UUID.randomUUID().toString();
-		String ext = file.getOriginalFilename().substring(file.getOriginalFilename().lastIndexOf(".") + 1);
+		String ext = getFileExt(file);
 		String filename = name + "." + ext;
 		try {
 			ObjectMetadata objMeta = new ObjectMetadata();

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/fileInfo/service/StorageServiceLocal.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/fileInfo/service/StorageServiceLocal.java
@@ -41,7 +41,7 @@ public class StorageServiceLocal implements StorageService {
 
 		// set unique file name
 		String name = UUID.randomUUID().toString();
-		String ext = file.getOriginalFilename().substring(file.getOriginalFilename().lastIndexOf(".") + 1);
+		String ext = getFileExt(file);
 		String filename = name + "." + ext;
 		Path dst = path.resolve(filename).normalize().toAbsolutePath();
 		if (Files.exists(dst)) {


### PR DESCRIPTION
## 개요
오전에 @CHOGANGYEOL 조강열님께서 제보해주신 이슈내용 해결하였습니다.

## 주요 작업사항
- 아지트 생성시 만남장소(location)값의 길이가 길어지면 아지트 생성이 안 되는 문제 해결
    - 시군구까지만 보내는줄 알아서 길이를 24로 제한하고 있었음
    - db에 저장되는 데이터의 길이를 24 -> 255로 변경
- 파일 저장시 요청값으로 보내는 file name에 확장자가 없는 경우 해결
    - 확장자 추출을 기존 file name에서 찾았던 것을 content type에서 찾도록 로직 수정

## 기능 외 변경사항(개발 범위 외 수정된 사항 등)

## 기타
- 아지트 생성시 나이 제한 관련해서 제한 없음으로 설정해서 보낼때 공백(`""`)이 아닌 `null`로 보내는 것으로 나이제한 이슈는 해결