### PR TITLE
[Review,], [Club] 참여자 리뷰 테스트 코드 작성, 아지트 부분 리팩토링

### DIFF
--- a/azit-back/src/docs/asciidoc/index.adoc
+++ b/azit-back/src/docs/asciidoc/index.adoc
@@ -478,6 +478,23 @@ include::{snippets}/post-club-report/http-response.adoc[]
 .response-fields
 include::{snippets}/post-club-report/response-fields.adoc[]
 
+=== 아지트 참여 질문 조회
+
+.curl-request
+include::{snippets}/get-club-join-question/curl-request.adoc[]
+
+.http-request
+include::{snippets}/get-club-join-question/http-request.adoc[]
+
+.path-parameters
+include::{snippets}/get-club-join-question/path-parameters.adoc[]
+
+.http-response
+include::{snippets}/get-club-join-question/http-response.adoc[]
+
+.response-fields
+include::{snippets}/get-club-join-question/response-fields.adoc[]
+
 == 아지트 참여
 
 === 참여 신청

--- a/azit-back/src/docs/asciidoc/index.adoc
+++ b/azit-back/src/docs/asciidoc/index.adoc
@@ -563,6 +563,74 @@ include::{snippets}/kick-club-members/request-headers.adoc[]
 .http-response
 include::{snippets}/kick-club-members/http-response.adoc[]
 
+== 참여자 리뷰
+
+=== 리뷰 작성
+
+.curl-request
+include::{snippets}/post-review/curl-request.adoc[]
+
+.http-request
+include::{snippets}/post-review/http-request.adoc[]
+
+.request-headers
+include::{snippets}/post-review/request-headers.adoc[]
+
+.request-fields
+include::{snippets}/post-review/request-fields.adoc[]
+
+.http-response
+include::{snippets}/post-review/http-response.adoc[]
+
+.response-fields
+include::{snippets}/post-review/response-fields.adoc[]
+
+=== 리뷰 숨김/숨김해제
+
+.curl-request
+include::{snippets}/patch-review/curl-request.adoc[]
+
+.http-request
+include::{snippets}/patch-review/http-request.adoc[]
+
+.path-parameters
+include::{snippets}/patch-review/path-parameters.adoc[]
+
+.request-headers
+include::{snippets}/patch-review/request-headers.adoc[]
+
+.request-fields
+include::{snippets}/patch-review/request-fields.adoc[]
+
+.http-response
+include::{snippets}/patch-review/http-response.adoc[]
+
+.response-fields
+include::{snippets}/patch-review/response-fields.adoc[]
+
+=== 회원 리뷰 조회
+
+.curl-request
+include::{snippets}/find-all-by-member/curl-request.adoc[]
+
+.http-request
+include::{snippets}/find-all-by-member/http-request.adoc[]
+
+.request-parameters
+include::{snippets}/find-all-by-member/request-parameters.adoc[]
+
+.request-headers
+include::{snippets}/find-all-by-member/request-headers.adoc[]
+
+.request-fields
+include::{snippets}/find-all-by-member/request-fields.adoc[]
+
+.http-response
+include::{snippets}/find-all-by-member/http-response.adoc[]
+
+.response-fields
+include::{snippets}/find-all-by-member/response-fields.adoc[]
+
 == 카테고리
 
 === 전체 카테고리 조회

--- a/azit-back/src/docs/asciidoc/index.adoc
+++ b/azit-back/src/docs/asciidoc/index.adoc
@@ -514,9 +514,6 @@ include::{snippets}/get-club-member/http-request.adoc[]
 .path-parameters
 include::{snippets}/get-club-member/path-parameters.adoc[]
 
-.request-parameters
-include::{snippets}/get-club-member/request-parameters.adoc[]
-
 .request-headers
 include::{snippets}/get-club-member/request-headers.adoc[]
 

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/club/controller/ClubController.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/club/controller/ClubController.java
@@ -1,6 +1,8 @@
 package com.codestates.azitserver.domain.club.controller;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -215,5 +217,20 @@ public class ClubController {
 		List<ClubDto.Response> responses = mapper.clubToClubDtoResponse(clubs);
 
 		return new ResponseEntity<>(new MultiResponseDto<>(responses, clubPage), HttpStatus.OK);
+	}
+
+	/**
+	 * 참여자 신청시 생성한 질문에 답할 수 있도록 질문 조회
+	 * @param clubId 조회할 아지트 고유 식별자
+	 * @return cludId와 joinQuestion을 담은 map
+	 */
+	@GetMapping("/{club-id}/join-question")
+	public ResponseEntity<?> getClubJoinQuestion(@Positive @PathVariable("club-id") Long clubId) {
+		String joinQuestion = clubService.getClubJoinQuestion(clubId);
+		Map<String, Object> response = new HashMap<>();
+		response.put("clubId", clubId);
+		response.put("joinQuestion", joinQuestion);
+
+		return new ResponseEntity<>(new SingleResponseDto<>(response), HttpStatus.OK);
 	}
 }

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/club/controller/ClubMemberController.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/club/controller/ClubMemberController.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import javax.validation.constraints.Positive;
 
-import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -14,7 +13,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.codestates.azitserver.domain.club.dto.ClubMemberDto;
@@ -23,7 +21,6 @@ import com.codestates.azitserver.domain.club.mapper.ClubMemberMapper;
 import com.codestates.azitserver.domain.club.service.ClubMemberService;
 import com.codestates.azitserver.domain.member.entity.Member;
 import com.codestates.azitserver.global.annotation.LoginMember;
-import com.codestates.azitserver.global.dto.MultiResponseDto;
 import com.codestates.azitserver.global.dto.SingleResponseDto;
 
 import lombok.RequiredArgsConstructor;
@@ -58,19 +55,14 @@ public class ClubMemberController {
 	/**
 	 * 특정 아지트에 참여신청을 보낸 사용자를 전체 조회합니다.
 	 * @param clubId 조회할 아지트 고유 식별자
-	 * @param page 페이지 번호
-	 * @param size 페이지에 들어갈 크기
 	 * @return 성공하면 상태값과 함께 참여 신청을 보낸 사용자를 담은 배열을 반환합니다.
 	 */
 	@GetMapping("/signups")
-	public ResponseEntity<?> getClubMember(@Positive @PathVariable("club-id") Long clubId,
-		@Positive @RequestParam(name = "page") int page,
-		@Positive @RequestParam(name = "size") int size) {
-		Page<ClubMember> clubMemberPage = clubMemberService.getAllClubMemberByClubId(clubId, page - 1, size);
-		List<ClubMember> clubMembers = clubMemberPage.getContent();
+	public ResponseEntity<?> getClubMember(@Positive @PathVariable("club-id") Long clubId) {
+		List<ClubMember> clubMembers = clubMemberService.getAllClubMemberByClubId(clubId);
 		List<ClubMemberDto.Response> responses = mapper.clubMemberToClubMemberDtoResponse(clubMembers);
 
-		return new ResponseEntity<>(new MultiResponseDto<>(responses, clubMemberPage), HttpStatus.OK);
+		return new ResponseEntity<>(new SingleResponseDto<>(responses), HttpStatus.OK);
 	}
 
 	/**

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/club/repository/ClubMemberRepository.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/club/repository/ClubMemberRepository.java
@@ -1,9 +1,8 @@
 package com.codestates.azitserver.domain.club.repository;
 
+import java.util.List;
 import java.util.Optional;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -15,5 +14,5 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
 	@Query("select cm from ClubMember cm where cm.member.memberId = :memberId and cm.club.clubId = :clubId")
 	Optional<ClubMember> findMemberJoinClub(Long memberId, Long clubId);
 
-	Page<ClubMember> findClubMembersByClub(Club Club, Pageable pageable);
+	List<ClubMember> findClubMembersByClub(Club Club);
 }

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/club/repository/ClubRepository.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/club/repository/ClubRepository.java
@@ -12,19 +12,22 @@ import com.codestates.azitserver.domain.category.entity.CategorySmall;
 import com.codestates.azitserver.domain.club.entity.Club;
 
 public interface ClubRepository extends JpaRepository<Club, Long> {
+	@Query("select c from Club c where c.clubStatus <> 'CLUB_CANCEL'")
+	Page<Club> findAllWithoutCanceled(Pageable pageable);
+
 	// SELECT * FROM CLUB INNER JOIN CATEGORY_SMALL WHERE CATEGORY_SMALL.CATEGORY_LARGE_ID = 1 AND CATEGORY_SMALL.CATEGORY_SMALL_ID = CLUB.CATEGORY_SMALL_ID
-	@Query("select c from Club c where c.categorySmall.categoryLarge.CategoryLargeId = :categoryLargeId")
+	@Query("select c from Club c where c.categorySmall.categoryLarge.CategoryLargeId = :categoryLargeId and c.clubStatus <> 'CLUB_CANCEL'")
 	Page<Club> findAllClubByCategoryLargeId(Long categoryLargeId, Pageable pageable);
 
 	// SELECT * FROM CLUB WHERE MEETING_DATE = {날짜}
-	@Query("select c from Club c where c.meetingDate = :targetDate")
+	@Query("select c from Club c where c.meetingDate = :targetDate and c.clubStatus <> 'CLUB_CANCEL'")
 	Page<Club> findAllClubsByClubMeetingDate(LocalDate targetDate, Pageable pageable);
 
 	// SELECT * FROM CLUB WHERE CLUB_NAME LIKE '%{keyword}%' OR CLUB_INFO LIKE '%{keyword}%';
-	@Query("select c from Club c where c.clubName like concat('%', :keyword, '%') or c.clubInfo like concat('%', :keyword, '%')")
+	@Query("select c from Club c where c.clubName like concat('%', :keyword, '%') or c.clubInfo like concat('%', :keyword, '%') and c.clubStatus <> 'CLUB_CANCEL'")
 	Page<Club> findAllClubsByNameOrInfoLikeKeywords(String keyword, Pageable pageable);
 
 	// SELECT * FROM CATEGORY_SMALL WHERE CATEGORY_SMALL_ID IN (1,7)
-	@Query("select c from Club  c where c.categorySmall in :categorySmall")
+	@Query("select c from Club  c where c.categorySmall in :categorySmall and c.clubStatus <> 'CLUB_CANCEL'")
 	Page<Club> findAllClubByCategorySmallIds(List<CategorySmall> categorySmall, Pageable pageable);
 }

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/club/service/ClubMemberService.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/club/service/ClubMemberService.java
@@ -1,10 +1,8 @@
 package com.codestates.azitserver.domain.club.service;
 
+import java.util.List;
 import java.util.Optional;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import com.codestates.azitserver.domain.club.entity.Club;
@@ -42,15 +40,12 @@ public class ClubMemberService {
 	/**
 	 * 특정 아지트에 참여신청을 보낸 사용자를 전체 조회합니다.
 	 * @param clubId 조회할 아지트 고유 식별자
-	 * @param page 페이지 번호
-	 * @param size 페이지에 들어갈 크기
 	 * @return 해당 아지트에 참여 신청을 보낸 사용자를 담은 pagenation 배열을 반환합니다.
 	 * @author cryoon
 	 */
-	public Page<ClubMember> getAllClubMemberByClubId(Long clubId, int page, int size) {
+	public List<ClubMember> getAllClubMemberByClubId(Long clubId) {
 		Club club = clubService.findClubById(clubId);
-		return clubMemberRepository.findClubMembersByClub(club,
-			PageRequest.of(page, size, Sort.by("clubMemberId").descending()));
+		return clubMemberRepository.findClubMembersByClub(club);
 	}
 
 	/**

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/club/service/ClubService.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/club/service/ClubService.java
@@ -164,4 +164,9 @@ public class ClubService {
 	public boolean verifyOrFindAll(Member member, Long memberId) {
 		return member == null || !memberId.equals(member.getMemberId());
 	}
+
+	public String getClubJoinQuestion(Long clubId) {
+		Club club = findClubById(clubId);
+		return club.getJoinQuestion();
+	}
 }

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/club/service/ClubService.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/club/service/ClubService.java
@@ -98,7 +98,7 @@ public class ClubService {
 	}
 
 	public Page<Club> findClubs(int page, int size) {
-		return clubRepository.findAll(PageRequest.of(page, size, Sort.by("createdAt").descending()));
+		return clubRepository.findAllWithoutCanceled(PageRequest.of(page, size, Sort.by("createdAt").descending()));
 	}
 
 	public Club findClubById(Long clubId) {

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/review/dto/ReviewDto.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/review/dto/ReviewDto.java
@@ -1,7 +1,5 @@
 package com.codestates.azitserver.domain.review.dto;
 
-import java.time.LocalDateTime;
-
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
 
@@ -10,8 +8,6 @@ import org.hibernate.validator.constraints.Length;
 import com.codestates.azitserver.domain.club.dto.ClubDto;
 import com.codestates.azitserver.domain.review.entity.Review;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -57,16 +53,14 @@ public class ReviewDto {
 	}
 
 	@Getter
-	@Builder
-	@AllArgsConstructor
+	@Setter
 	@NoArgsConstructor
 	public static class Response {
 		private Long reviewId;
 		private Long revieweeId;
 		private ClubDto.ReviewClubResponse club;
-		private Review.CommentCategory commentCategory;
+		private String  commentCategory;
 		private String commentBody;
 		private Boolean reviewStatus;
-		private LocalDateTime createdAt;
 	}
 }

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/review/mapper/ReviewMapper.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/review/mapper/ReviewMapper.java
@@ -16,6 +16,7 @@ public interface ReviewMapper {
 	Review reviewDtoPostToReview(ReviewDto.Post post);
 
 	@Mapping(source = "reviewee.memberId", target = "revieweeId")
+	@Mapping(source = "commentCategory.commentCategory", target = "commentCategory")
 	ReviewDto.Response reviewToReviewDtoResponse(Review review);
 
 	List<ReviewDto.Response> reviewToReviewDtoResponse(List<Review> reviews);

--- a/azit-back/src/test/java/com/codestates/azitserver/domain/club/controller/ClubControllerTest.java
+++ b/azit-back/src/test/java/com/codestates/azitserver/domain/club/controller/ClubControllerTest.java
@@ -3,6 +3,8 @@ package com.codestates.azitserver.domain.club.controller;
 import static com.codestates.azitserver.global.utils.AsciiDocsUtils.*;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.restdocs.snippet.Attributes.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
@@ -24,6 +26,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.util.LinkedMultiValueMap;
@@ -394,5 +397,35 @@ class ClubControllerTest implements ClubControllerTestHelper {
 				),
 				ClubFieldDescriptor.getMultiResponseSnippet()
 			));
+	}
+
+	@Test
+	public void getClubJoinQuestion() throws Exception {
+		// given
+		Long clubId = 1L;
+		String joinQuestion = "참여 신청 질문입니다.";
+
+		given(clubService.getClubJoinQuestion(Mockito.anyLong())).willReturn(joinQuestion);
+
+		// when
+		ResultActions actions = mockMvc.perform(get(getClubUri() + "/join-question", clubId)
+			.accept(MediaType.APPLICATION_JSON)
+			.characterEncoding(StandardCharsets.UTF_8));
+
+		// then
+		actions.andDo(print())
+			.andExpect(status().isOk())
+			.andDo(getDefaultDocument("get-club-join-question",
+					pathParameters(List.of(
+						parameterWithName("club-id").description("아지트 고유 식별자"))
+					),
+					responseFields(
+						fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터")
+					).andWithPrefix("data.",
+						fieldWithPath("clubId").type(JsonFieldType.NUMBER).description("아지트 고유 식별자"),
+						fieldWithPath("joinQuestion").type(JsonFieldType.STRING).description("참가 신청 질문")
+					)
+				)
+			);
 	}
 }

--- a/azit-back/src/test/java/com/codestates/azitserver/domain/club/controller/ClubMemberControllerTest.java
+++ b/azit-back/src/test/java/com/codestates/azitserver/domain/club/controller/ClubMemberControllerTest.java
@@ -25,8 +25,6 @@ import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
 
 import com.codestates.azitserver.domain.club.controller.descriptor.ClubMemberFieldDescriptor;
 import com.codestates.azitserver.domain.club.controller.helper.ClubMemberControllerTestHelper;
@@ -107,17 +105,12 @@ class ClubMemberControllerTest implements ClubMemberControllerTestHelper {
 	@Test
 	void getClubMember() throws Exception {
 		// given
-		MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
-		queryParams.add("page", "1");
-		queryParams.add("size", "10");
-
-		given(clubMemberService.getAllClubMemberByClubId(Mockito.anyLong(), Mockito.anyInt(), Mockito.anyInt()))
-			.willReturn(clubMemberPage);
+		given(clubMemberService.getAllClubMemberByClubId(Mockito.anyLong())).willReturn(List.of(clubMember));
 		given(mapper.clubMemberToClubMemberDtoResponse(Mockito.anyList())).willReturn(List.of(response));
 
 		// when
 		ResultActions actions = mockMvc.perform(
-			getRequestBuilder(getClubMemberUrl("signups"), queryParams, 1L)
+			getRequestBuilder(getClubMemberUrl("signups"), 1L)
 				.header("Authorization", "Required JWT access token"));
 
 		// then
@@ -125,11 +118,6 @@ class ClubMemberControllerTest implements ClubMemberControllerTestHelper {
 			.andExpect(status().isOk())
 			.andDo(getDefaultDocument("get-club-member",
 				requestHeaders(headerWithName("Authorization").description("Jwt Access Token")),
-				requestParameters(
-					List.of(
-						parameterWithName("page").description("Page 번호"),
-						parameterWithName("size").description("Page 크기")
-					)),
 				pathParameters(List.of(
 					parameterWithName("club-id").description("아지트 고유 식별자"))),
 				ClubMemberFieldDescriptor.getMultiResponseFieldSnippet()

--- a/azit-back/src/test/java/com/codestates/azitserver/domain/club/controller/descriptor/ClubMemberFieldDescriptor.java
+++ b/azit-back/src/test/java/com/codestates/azitserver/domain/club/controller/descriptor/ClubMemberFieldDescriptor.java
@@ -61,13 +61,6 @@ public class ClubMemberFieldDescriptor {
 			fieldWithPath("fileId").type(JsonFieldType.NUMBER).description("프로필 사진 고유 식별자"),
 			fieldWithPath("fileName").type(JsonFieldType.STRING).description("프로필 사진 파일명"),
 			fieldWithPath("fileUrl").type(JsonFieldType.STRING).description("프로핀 사진 파일 경로")
-		).and(
-			fieldWithPath("pageInfo").type(JsonFieldType.OBJECT).description("페이지 정보")
-		).andWithPrefix("pageInfo.",
-			fieldWithPath("page").type(JsonFieldType.NUMBER).description("요청한 페이지"),
-			fieldWithPath("size").type(JsonFieldType.NUMBER).description("요청한 개수"),
-			fieldWithPath("totalPages").type(JsonFieldType.NUMBER).description("총 페이지 수"),
-			fieldWithPath("totalElements").type(JsonFieldType.NUMBER).description("총 개수")
 		);
 	}
 }

--- a/azit-back/src/test/java/com/codestates/azitserver/domain/review/controller/ReviewControllerTest.java
+++ b/azit-back/src/test/java/com/codestates/azitserver/domain/review/controller/ReviewControllerTest.java
@@ -1,0 +1,157 @@
+package com.codestates.azitserver.domain.review.controller;
+
+import static com.codestates.azitserver.global.utils.AsciiDocsUtils.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import com.codestates.azitserver.domain.review.descriptor.ReviewFieldsDescriptor;
+import com.codestates.azitserver.domain.review.dto.ReviewDto;
+import com.codestates.azitserver.domain.review.entity.Review;
+import com.codestates.azitserver.domain.review.helper.ReviewControllerTestHelper;
+import com.codestates.azitserver.domain.review.mapper.ReviewMapper;
+import com.codestates.azitserver.domain.review.service.ReviewService;
+import com.codestates.azitserver.domain.stub.ReviewStubData;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@AutoConfigureRestDocs
+@AutoConfigureMockMvc(addFilters = false)
+@MockBean(JpaMetamodelMappingContext.class)
+@WebMvcTest(controllers = ReviewController.class, excludeAutoConfiguration = SecurityAutoConfiguration.class)
+class ReviewControllerTest implements ReviewControllerTestHelper {
+	@Autowired
+	MockMvc mockMvc;
+
+	@Autowired
+	ObjectMapper objectMapper;
+
+	@MockBean
+	ReviewService reviewService;
+
+	@MockBean
+	ReviewMapper mapper;
+
+	Review review;
+	ReviewDto.Post post;
+	ReviewDto.Patch patch;
+	ReviewDto.Get get;
+	ReviewDto.Response response;
+	Page<Review> reviewPage;
+
+	@BeforeEach
+	public void beforeEach() {
+		review = ReviewStubData.getDefaultReview();
+		post = ReviewStubData.getReviewDtoPost();
+		patch = ReviewStubData.getReviewDtoPatch();
+		get = ReviewStubData.getReviewDtoGet();
+		response = ReviewStubData.getReviewDtoResponse();
+		reviewPage = ReviewStubData.getReviewPage();
+	}
+
+	@Test
+	void postReview() throws Exception {
+		// given
+		given(mapper.reviewDtoPostToReview(Mockito.any(ReviewDto.Post.class))).willReturn(review);
+		given(reviewService.createReview(Mockito.any(), Mockito.any(Review.class))).willReturn(review);
+		given(mapper.reviewToReviewDtoResponse(Mockito.any(Review.class))).willReturn(response);
+
+		String content = objectMapper.writeValueAsString(post);
+
+		// when
+		ResultActions actions = mockMvc.perform(postRequestBuilder(createURI(getReviewUrl()), content)
+			.header("Authorization", "Required JWT access token").characterEncoding(StandardCharsets.UTF_8));
+
+		// then
+		actions.andDo(print())
+			.andExpect(status().isCreated())
+			.andDo(getDefaultDocument("post-review",
+					requestHeaders(headerWithName("Authorization").description("Jwt Access Token")),
+					ReviewFieldsDescriptor.getPostRequestFieldsSnippet(),
+					ReviewFieldsDescriptor.getSingleResponseFieldsSnippet()
+				)
+			);
+	}
+
+	@Test
+	void patchReview() throws Exception {
+		// given
+		response.setReviewStatus(true);
+		given(reviewService.updateReviewStatus(Mockito.any(), Mockito.anyLong(), Mockito.anyBoolean()))
+			.willReturn(review);
+		given(mapper.reviewToReviewDtoResponse(Mockito.any(Review.class))).willReturn(response);
+
+		String content = objectMapper.writeValueAsString(patch);
+
+		// when
+		ResultActions actions = mockMvc.perform(patchRequestBuilder(getReviewUri(), content, 1L)
+			.header("Authorization", "Required JWT access token").characterEncoding(StandardCharsets.UTF_8));
+
+		// then
+		actions.andDo(print())
+			.andExpect(status().isOk())
+			.andDo(getDefaultDocument("patch-review",
+					pathParameters(List.of(
+						parameterWithName("review-id").description("리뷰 고유 식별자"))
+					),
+					requestHeaders(headerWithName("Authorization").description("Jwt Access Token")),
+					ReviewFieldsDescriptor.getPatchRequestFieldsSnippet(),
+					ReviewFieldsDescriptor.getSingleResponseFieldsSnippet()
+				)
+			);
+	}
+
+	@Test
+	void findAllByMember() throws Exception {
+		// given
+		MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
+		queryParams.add("page", "1");
+		queryParams.add("size", "10");
+
+		String content = objectMapper.writeValueAsString(get);
+
+		given(reviewService.findReviewByRevieweeId(Mockito.any(), Mockito.anyLong(), Mockito.anyInt(),
+			Mockito.anyInt())).willReturn(reviewPage);
+		given(mapper.reviewToReviewDtoResponse(Mockito.anyList())).willReturn(List.of(response));
+
+		// when
+		ResultActions actions = mockMvc.perform(getRequestBuilder(getReviewUrl(), queryParams, content)
+			.header("Authorization", "Required JWT access token(Optional)"));
+
+		// then
+		actions.andDo(print())
+			.andExpect(status().isOk())
+			.andDo(getDefaultDocument("find-all-by-member",
+					requestHeaders(headerWithName("Authorization").description("Jwt Access Token(Optional)")),
+					requestParameters(
+						List.of(
+							parameterWithName("page").description("Page 번호"),
+							parameterWithName("size").description("Page 크기")
+						)
+					),
+					ReviewFieldsDescriptor.getSetRequestFieldsSnippet(),
+					ReviewFieldsDescriptor.getMultiResponseFieldsSnippet()
+				)
+			);
+	}
+}

--- a/azit-back/src/test/java/com/codestates/azitserver/domain/review/descriptor/ReviewFieldsDescriptor.java
+++ b/azit-back/src/test/java/com/codestates/azitserver/domain/review/descriptor/ReviewFieldsDescriptor.java
@@ -1,0 +1,84 @@
+package com.codestates.azitserver.domain.review.descriptor;
+
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.snippet.Attributes.*;
+
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.payload.RequestFieldsSnippet;
+import org.springframework.restdocs.payload.ResponseFieldsSnippet;
+import org.springframework.restdocs.snippet.Snippet;
+
+public class ReviewFieldsDescriptor {
+	public static RequestFieldsSnippet getPostRequestFieldsSnippet() {
+		return requestFields(
+			fieldWithPath("reviewerId").type(JsonFieldType.NUMBER).description("리뷰 쓰는 사용자 고유 식별자"),
+			fieldWithPath("revieweeId").type(JsonFieldType.NUMBER).description("리뷰 대상자 고유 식별자"),
+			fieldWithPath("clubId").type(JsonFieldType.NUMBER).description("리뷰어, 리뷰이가 참여하고 있는 아지트 고유 식별자"),
+			fieldWithPath("commentCategory").type(JsonFieldType.STRING)
+				.description("리뷰 카테고리")
+				.attributes(key("constraints").value("enum으로 분류")),
+			fieldWithPath("commentBody").type(JsonFieldType.STRING).description("상세 리뷰 내용").optional()
+		);
+	}
+
+	public static RequestFieldsSnippet getPatchRequestFieldsSnippet() {
+		return requestFields(
+			fieldWithPath("reviewStatus").type(JsonFieldType.BOOLEAN)
+				.description("리뷰 숨김처리 여부")
+				.attributes(key("constraints").value("true: 숨김 | false: 공개"))
+		);
+	}
+
+	public static Snippet getSetRequestFieldsSnippet() {
+		return requestFields(
+			fieldWithPath("revieweeId").type(JsonFieldType.NUMBER).description("리뷰 대상자 고유 식별자")
+		);
+	}
+
+	public static ResponseFieldsSnippet getSingleResponseFieldsSnippet() {
+		return responseFields(
+			fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터")
+		).andWithPrefix("data.",
+			fieldWithPath("reviewId").type(JsonFieldType.NUMBER).description("리뷰 고유 식별자"),
+			fieldWithPath("revieweeId").type(JsonFieldType.NUMBER).description("리뷰 대상자 고유 식별자"),
+			fieldWithPath("commentCategory").type(JsonFieldType.STRING).description("리뷰 카테고리(enum의 value값)"),
+			fieldWithPath("commentBody").type(JsonFieldType.STRING).description("상세 리뷰 내용"),
+			fieldWithPath("reviewStatus").type(JsonFieldType.BOOLEAN)
+				.description("리뷰 숨김처리 여부")
+				.attributes(key("constraints").value("true: 숨김 | false: 공개"))
+		).and(
+			fieldWithPath("data.club").type(JsonFieldType.OBJECT).description("리뷰어, 리뷰이가 참여하고 있는 아지트 데이터")
+		).andWithPrefix("data.club.",
+			fieldWithPath("clubId").type(JsonFieldType.NUMBER).description("아지트 고유 식별자"),
+			fieldWithPath("clubName").type(JsonFieldType.STRING).description("아지트 이름"),
+			fieldWithPath("meetingDate").type(JsonFieldType.STRING).description("약속 날짜")
+		);
+	}
+
+	public static ResponseFieldsSnippet getMultiResponseFieldsSnippet() {
+		return responseFields(
+			fieldWithPath("data").type(JsonFieldType.ARRAY).description("응답 데이터")
+		).andWithPrefix("data[].",
+			fieldWithPath("reviewId").type(JsonFieldType.NUMBER).description("리뷰 고유 식별자"),
+			fieldWithPath("revieweeId").type(JsonFieldType.NUMBER).description("리뷰 대상자 고유 식별자"),
+			fieldWithPath("commentCategory").type(JsonFieldType.STRING).description("리뷰 카테고리(enum의 value값)"),
+			fieldWithPath("commentBody").type(JsonFieldType.STRING).description("상세 리뷰 내용"),
+			fieldWithPath("reviewStatus").type(JsonFieldType.BOOLEAN)
+				.description("리뷰 숨김처리 여부")
+				.attributes(key("constraints").value("true: 숨김 | false: 공개"))
+		).and(
+			fieldWithPath("data[].club").type(JsonFieldType.OBJECT).description("리뷰어, 리뷰이가 참여하고 있는 아지트 데이터")
+		).andWithPrefix("data[].club.",
+			fieldWithPath("clubId").type(JsonFieldType.NUMBER).description("아지트 고유 식별자"),
+			fieldWithPath("clubName").type(JsonFieldType.STRING).description("아지트 이름"),
+			fieldWithPath("meetingDate").type(JsonFieldType.STRING).description("약속 날짜")
+		).and(
+			fieldWithPath("pageInfo").type(JsonFieldType.OBJECT).description("페이지 정보")
+		).andWithPrefix("pageInfo.",
+			fieldWithPath("page").type(JsonFieldType.NUMBER).description("요청한 페이지"),
+			fieldWithPath("size").type(JsonFieldType.NUMBER).description("요청한 개수"),
+			fieldWithPath("totalPages").type(JsonFieldType.NUMBER).description("총 페이지 수"),
+			fieldWithPath("totalElements").type(JsonFieldType.NUMBER).description("총 개수")
+		);
+	}
+}

--- a/azit-back/src/test/java/com/codestates/azitserver/domain/review/helper/ReviewControllerTestHelper.java
+++ b/azit-back/src/test/java/com/codestates/azitserver/domain/review/helper/ReviewControllerTestHelper.java
@@ -1,0 +1,17 @@
+package com.codestates.azitserver.domain.review.helper;
+
+import com.codestates.azitserver.global.utils.ControllerTestHelper;
+
+public interface ReviewControllerTestHelper extends ControllerTestHelper {
+	String REVIEW_URL = "/api/reviews";
+
+	String REVIEW_RESOURCE_URI = "/{review-id}";
+
+	default String getReviewUrl() {
+		return REVIEW_URL;
+	}
+
+	default String getReviewUri() {
+		return REVIEW_URL + REVIEW_RESOURCE_URI;
+	}
+}

--- a/azit-back/src/test/java/com/codestates/azitserver/domain/stub/ClubStubData.java
+++ b/azit-back/src/test/java/com/codestates/azitserver/domain/stub/ClubStubData.java
@@ -131,4 +131,14 @@ public class ClubStubData {
 
 		return reportClubResponse;
 	}
+
+	public static ClubDto.ReviewClubResponse getClubDtoReviewClubResponse() {
+		ClubDto.ReviewClubResponse reviewClubResponse = new ClubDto.ReviewClubResponse();
+
+		reviewClubResponse.setClubId(1L);
+		reviewClubResponse.setClubName("재밌는 아지트");
+		reviewClubResponse.setMeetingDate(LocalDate.now().minusDays(1));
+
+		return reviewClubResponse;
+	}
 }

--- a/azit-back/src/test/java/com/codestates/azitserver/domain/stub/ReviewStubData.java
+++ b/azit-back/src/test/java/com/codestates/azitserver/domain/stub/ReviewStubData.java
@@ -1,0 +1,73 @@
+package com.codestates.azitserver.domain.stub;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+
+import com.codestates.azitserver.domain.review.dto.ReviewDto;
+import com.codestates.azitserver.domain.review.entity.Review;
+
+public class ReviewStubData {
+	public static Review getDefaultReview() {
+		Review review = new Review();
+
+		review.setReviewId(1L);
+		review.setReviewer(MemberStubData.stubMember());
+		review.setReviewee(MemberStubData.stubMember());
+		review.setClub(ClubStubData.getDefaultClub());
+		review.setCommentCategory(Review.CommentCategory.CONSIDERATE);
+		review.setCommentBody("마음씨가 너무 착해요.");
+		review.setReviewStatus(false);
+
+		return review;
+	}
+
+	public static ReviewDto.Post getReviewDtoPost() {
+		ReviewDto.Post post = new ReviewDto.Post();
+
+		post.setReviewerId(1L);
+		post.setRevieweeId(2L);
+		post.setClubId(3L);
+		post.setCommentCategory(Review.CommentCategory.CONSIDERATE);
+		post.setCommentBody("마음씨가 너무 착해요.");
+
+		return post;
+	}
+
+	public static ReviewDto.Patch getReviewDtoPatch() {
+		ReviewDto.Patch patch = new ReviewDto.Patch();
+
+		patch.setReviewStatus(true);
+
+		return patch;
+	}
+
+	public static ReviewDto.Get getReviewDtoGet() {
+		ReviewDto.Get get = new ReviewDto.Get();
+
+		get.setRevieweeId(2L);
+
+		return get;
+	}
+
+	public static ReviewDto.Response getReviewDtoResponse() {
+		ReviewDto.Response response = new ReviewDto.Response();
+
+		response.setReviewId(1L);
+		response.setRevieweeId(2L);
+		response.setClub(ClubStubData.getClubDtoReviewClubResponse());
+		response.setCommentCategory(Review.CommentCategory.CONSIDERATE.getCommentCategory());
+		response.setCommentBody("마음씨가 너무 착해요.");
+		response.setReviewStatus(false);
+
+		return response;
+	}
+
+	public static Page<Review> getReviewPage() {
+		return new PageImpl<>(List.of(getDefaultReview()), PageRequest.of(0, 10,
+			Sort.by("createdAt").descending()), 1);
+	}
+}

--- a/azit-back/src/test/java/com/codestates/azitserver/global/utils/ControllerTestHelper.java
+++ b/azit-back/src/test/java/com/codestates/azitserver/global/utils/ControllerTestHelper.java
@@ -49,6 +49,15 @@ public interface ControllerTestHelper {
 			.accept(MediaType.APPLICATION_JSON);
 	}
 
+	default MockHttpServletRequestBuilder getRequestBuilder(String url, MultiValueMap<String, String> queryParams, String content, Object... urlVariables) {
+		return get(url, urlVariables)
+			.queryParams(queryParams)
+			.accept(MediaType.APPLICATION_JSON)
+			.contentType(MediaType.APPLICATION_JSON)
+			.characterEncoding(StandardCharsets.UTF_8)
+			.content(content);
+	}
+
 	default MockHttpServletRequestBuilder getRequestBuilder(String url, long resourceId) {
 		return get(url, resourceId)
 			.accept(MediaType.APPLICATION_JSON);


### PR DESCRIPTION
## 개요
오후에 완성한 참여자 리뷰 컨트롤러 테스트 및 api 문서 작성했습니다.
또한 프론트 담당자분 요청에 따라 아지트 부분 일부 리팩토림 되었습니다.

## 주요 작업사항
- 리뷰 응답값에 리뷰 카테고리를 enum의 상수값이 아닌 value값을 담도록 수정
- 리뷰 컨트롤러 테스트 코드 구현 및 api 문서 작성

- 아지트 조회시 취소된 아지트까지 보여지는 현상 안보이도록 수정
- 아지트 참여 신청시 질문을 받와야하므로 해당 아지트 질문 조회하는 api 작성
- 아지트 참여 신청자 조회시 페이지네이션이 아닌 전체 멤버를 조회해오도록 수정

## 기능 외 변경사항(개발 범위 외 수정된 사항 등)

## 기타