### PR TITLE
feat: 아지트 신청 수락/거절 및 강퇴 기능 구현

### DIFF
--- a/azit-front/src/components/AzitEdit/AzitEditForm.js
+++ b/azit-front/src/components/AzitEdit/AzitEditForm.js
@@ -293,7 +293,6 @@ const AzitEditForm = () => {
     isOnline: check,
     location: writeInfo,
   };
-  console.log(body);
 
   const navigate = useNavigate();
 

--- a/azit-front/src/components/AzitMember/Member.js
+++ b/azit-front/src/components/AzitMember/Member.js
@@ -1,5 +1,4 @@
 import styled from "styled-components";
-import { AzitMemberData } from "../../dummyData/AzitMemberData";
 import MemberList from "./MemberList";
 
 const WaitingWrap = styled.article`

--- a/azit-front/src/components/AzitMember/MemberList.js
+++ b/azit-front/src/components/AzitMember/MemberList.js
@@ -124,7 +124,7 @@ const MemberList = ({ data, state }) => {
   return (
     <ListWrap key={data.clubMemberId}>
       <div className="userWrap">
-        <Link to="/userpage" className="avatarWrap">
+        <Link to={`/userpage/${data.member.memberId}`} className="avatarWrap">
           <img
             alt={data.userName}
             src={`${process.env.REACT_APP_S3_URL}${data.member.fileInfo.fileUrl}/${data.member.fileInfo.fileName}`}

--- a/azit-front/src/components/AzitMember/MemberList.js
+++ b/azit-front/src/components/AzitMember/MemberList.js
@@ -1,6 +1,8 @@
 import { Link } from "react-router-dom";
 import styled from "styled-components";
 import ExportIcon from "../../images/exportIcon.png";
+import { axiosInstance } from "../../util/axios";
+import { useParams } from "react-router-dom";
 
 const ListWrap = styled.li`
   margin-top: 1rem;
@@ -77,8 +79,50 @@ const ListWrap = styled.li`
 `;
 
 const MemberList = ({ data, state }) => {
+  const { id } = useParams();
+
+  const azitMemberAccept = async () => {
+    try {
+      const payload = { status: "CLUB_JOINED" };
+      await axiosInstance.patch(
+        `api/clubs/${id}/signups/${data.member.memberId}`,
+        payload,
+        {
+          headers: {
+            Authorization: localStorage.getItem("accessToken"),
+            "Content-Type": "application/json",
+          },
+        }
+      );
+      window.location.reload();
+      console.log("아지트 참가 수락 완료");
+    } catch (e) {
+      console.log("아지트 참가 수락 실패");
+    }
+  };
+
+  const azitMemberDeny = async () => {
+    try {
+      const payload = { status: "CLUB_REJECTED" };
+      await axiosInstance.patch(
+        `api/clubs/${id}/signups/${data.member.memberId}`,
+        payload,
+        {
+          headers: {
+            Authorization: localStorage.getItem("accessToken"),
+            "Content-Type": "application/json",
+          },
+        }
+      );
+      window.location.reload();
+      console.log("아지트 참가 거절 완료");
+    } catch (e) {
+      console.log("아지트 참가 거절 실패");
+    }
+  };
+
   return (
-    <ListWrap>
+    <ListWrap key={data.clubMemberId}>
       <div className="userWrap">
         <Link to="/userpage" className="avatarWrap">
           <img
@@ -94,8 +138,12 @@ const MemberList = ({ data, state }) => {
           <div className="btnWrap">
             {state === "CLUB_WAITING" ? (
               <>
-                <button className="watingBtn accept">수락</button>
-                <button className="watingBtn reject">거절</button>
+                <button className="watingBtn accept" onClick={azitMemberAccept}>
+                  수락
+                </button>
+                <button className="watingBtn reject" onClick={azitMemberDeny}>
+                  거절
+                </button>
               </>
             ) : (
               <button className="export">

--- a/azit-front/src/components/AzitMember/MemberList.js
+++ b/azit-front/src/components/AzitMember/MemberList.js
@@ -94,7 +94,7 @@ const MemberList = ({ data, state }) => {
           },
         }
       );
-      window.location.reload();
+
       console.log("아지트 참가 수락 완료");
     } catch (e) {
       console.log("아지트 참가 수락 실패");
@@ -114,10 +114,29 @@ const MemberList = ({ data, state }) => {
           },
         }
       );
-      window.location.reload();
+
       console.log("아지트 참가 거절 완료");
     } catch (e) {
       console.log("아지트 참가 거절 실패");
+    }
+  };
+
+  const azitMemberKicks = async () => {
+    try {
+      await axiosInstance.patch(
+        `api/clubs/${id}/kicks/${data.member.memberId}`,
+
+        {
+          headers: {
+            Authorization: localStorage.getItem("accessToken"),
+            "Content-Type": "application/json",
+          },
+        }
+      );
+
+      console.log("아지트 강퇴");
+    } catch (e) {
+      console.log("아지트 강퇴 실패");
     }
   };
 
@@ -146,7 +165,7 @@ const MemberList = ({ data, state }) => {
                 </button>
               </>
             ) : (
-              <button className="export">
+              <button className="export" onClick={azitMemberKicks}>
                 <img alt="exportIcon" src={ExportIcon} />
               </button>
             )}

--- a/azit-front/src/pages/AzitDetail.js
+++ b/azit-front/src/pages/AzitDetail.js
@@ -287,7 +287,6 @@ const AzitDetail = () => {
       });
       setClubMember(filterMember);
     }
-    console.log(data);
   }, [data]);
 
   return (


### PR DESCRIPTION
아지트 신청 수락/거절 기능을 구현했습니다.
- 수락/거절 기능을 잘 되나 새로고침 시 반영이 되지만 바로 화면에 반영이 안되고 있음
- window.location.reload()를 이용하려고 했으나 로그인이 풀려버림.

아지트 강퇴 기능 구현 완료
- 헤더에 토큰을 추가해서 보내고 있으나 401에러가 뜨며 권한이 없다고 나옴. 추후에 담당자님과 의논 필요