### PR TITLE
[Fix/review,  clubMember] 리뷰 도메인 관련 수정사항 업데이트

### DIFF
--- a/azit-back/src/docs/asciidoc/index.adoc
+++ b/azit-back/src/docs/asciidoc/index.adoc
@@ -591,7 +591,7 @@ include::{snippets}/kick-club-members/request-headers.adoc[]
 .http-response
 include::{snippets}/kick-club-members/http-response.adoc[]
 
-=== 아지트 참여 회원 강퇴
+=== 아지트 참여 신청 취소 및 나가기
 
 .curl-request
 include::{snippets}/delete-club-members/curl-request.adoc[]

--- a/azit-back/src/docs/asciidoc/index.adoc
+++ b/azit-back/src/docs/asciidoc/index.adoc
@@ -650,8 +650,8 @@ include::{snippets}/find-all-by-member/request-parameters.adoc[]
 .request-headers
 include::{snippets}/find-all-by-member/request-headers.adoc[]
 
-.request-fields
-include::{snippets}/find-all-by-member/request-fields.adoc[]
+.path-parameters
+include::{snippets}/find-all-by-member/path-parameters.adoc[]
 
 .http-response
 include::{snippets}/find-all-by-member/http-response.adoc[]

--- a/azit-back/src/docs/asciidoc/index.adoc
+++ b/azit-back/src/docs/asciidoc/index.adoc
@@ -591,6 +591,23 @@ include::{snippets}/kick-club-members/request-headers.adoc[]
 .http-response
 include::{snippets}/kick-club-members/http-response.adoc[]
 
+=== 아지트 참여 회원 강퇴
+
+.curl-request
+include::{snippets}/delete-club-members/curl-request.adoc[]
+
+.http-request
+include::{snippets}/delete-club-members/http-request.adoc[]
+
+.path-parameters
+include::{snippets}/delete-club-members/path-parameters.adoc[]
+
+.request-headers
+include::{snippets}/delete-club-members/request-headers.adoc[]
+
+.http-response
+include::{snippets}/delete-club-members/http-response.adoc[]
+
 == 참여자 리뷰
 
 === 리뷰 작성

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/club/controller/ClubController.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/club/controller/ClubController.java
@@ -37,10 +37,6 @@ import com.codestates.azitserver.global.dto.SingleResponseDto;
 
 import lombok.RequiredArgsConstructor;
 
-/**
- * TODO : Login 피트가 구현 되면 Member Principal을 받아와 요청의 주체와, 요청의 대상을 검증하는 로직 추가.
- * TODO : Member 파트가 구현 되면 관심 카테고리, 회원이 참여한 정보를 가져와 조회 api 완성.
- */
 @Validated
 @RestController
 @RequiredArgsConstructor

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/club/controller/ClubMemberController.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/club/controller/ClubMemberController.java
@@ -7,6 +7,7 @@ import javax.validation.constraints.Positive;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -88,6 +89,14 @@ public class ClubMemberController {
 		@Positive @PathVariable("member-id") Long memberId,
 		@LoginMember Member member) {
 		clubMemberService.kickMember(member, clubId, memberId);
+
+		return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+	}
+
+	@DeleteMapping("/signups/{member-id:[0-9]+}")
+	public ResponseEntity<?> deleteClubMembers(@Positive @PathVariable("club-id") Long clubId,
+	@Positive @PathVariable("member-id") Long memberId, @LoginMember Member member) {
+		clubMemberService.deleteClubMember(member, clubId, memberId);
 
 		return new ResponseEntity<>(HttpStatus.NO_CONTENT);
 	}

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/club/entity/Club.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/club/entity/Club.java
@@ -103,8 +103,6 @@ public class Club extends Auditable {
 		return clubMember;
 	}
 
-	// TODO: banner_image, host_id, club_members
-
 	public enum JoinMethod {
 		APPROVAL("승인제"),
 		FIRST_COME("선착순");

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/club/service/ClubMemberService.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/club/service/ClubMemberService.java
@@ -103,6 +103,28 @@ public class ClubMemberService {
 		clubMemberRepository.save(clubMember);
 	}
 
+	/**
+	 * 회원은 본인이 신청한 아지트를 신청 취소 할 수 있다.
+	 * @param member 요청을 보낸 회원
+	 * @param clubId 취소할 아지트 고유 식별자
+	 * @param memberId 취소할 아지트의 회원 고유 식볋자
+	 */
+	public void deleteClubMember(Member member, Long clubId, Long memberId) {
+		verifyMember(member, memberId);
+
+		// 참여하려는 클럽이 존재하는 클럽이거나, 취소된 클럽인지 확인힙니다.
+		clubService.findClubById(clubId);
+
+		// 취소하려는 사용자가 아지트에 신청한 회원이 맞고, 상태가 신청 대기, 승인됨이 맞는지 확인합니다.
+		ClubMember clubMember = findClubMemberByMemberIdAndClubId(memberId, clubId);
+		if (clubMember.getClubMemberStatus() != ClubMember.ClubMemberStatus.CLUB_JOINED
+			& clubMember.getClubMemberStatus() != ClubMember.ClubMemberStatus.CLUB_WAITING) {
+			throw new BusinessLogicException(ExceptionCode.INVALID_CLUB_MEMBER_STATUS);
+		}
+
+		clubMemberRepository.deleteById(clubMember.getClubMemberId());
+	}
+
 	// *** verification ***
 	public void verifyMember(Member member, Long memberId) {
 		if (!member.getMemberId().equals(memberId)) {

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/member/dto/MemberDto.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/member/dto/MemberDto.java
@@ -131,6 +131,7 @@ public class MemberDto {
 		private Long memberId;
 		private String email;
 		private String nickname;
+		private String aboutMe;
 		private FileInfoDto.Response fileInfo;
 	}
 

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/review/controller/ReviewController.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/review/controller/ReviewController.java
@@ -1,5 +1,6 @@
 package com.codestates.azitserver.domain.review.controller;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.validation.constraints.Positive;
@@ -35,11 +36,24 @@ public class ReviewController {
 	private final ReviewMapper mapper;
 
 	//리뷰 작성
-	@PostMapping
+	// @PostMapping
 	public ResponseEntity<?> postReview(@RequestBody ReviewDto.Post post, @LoginMember Member member) {
 		Review postToReview = mapper.reviewDtoPostToReview(post);
 		Review review = reviewService.createReview(member, postToReview);
 		ReviewDto.Response response = mapper.reviewToReviewDtoResponse(review);
+
+		return new ResponseEntity<>(response, HttpStatus.CREATED);
+	}
+
+	// TODO : 트랜잭션 문제 해결하기 -> 여러 리뷰 작성중 한개라도 성공하지 못하면 나머지 작성 리뷰 또한 롤백 되어야 함
+	// 여러개의 리뷰 작성
+	@PostMapping
+	public ResponseEntity<?> postReviews(@RequestBody List<ReviewDto.Post> posts, @LoginMember Member member) {
+		List<ReviewDto.Response> response = new ArrayList<>();
+		for (ReviewDto.Post post: posts ) {
+			ResponseEntity<?> responseEntity = postReview(post, member);
+			response.add((ReviewDto.Response)responseEntity.getBody());
+		}
 
 		return new ResponseEntity<>(new SingleResponseDto<>(response), HttpStatus.CREATED);
 	}

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/review/controller/ReviewController.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/review/controller/ReviewController.java
@@ -55,11 +55,12 @@ public class ReviewController {
 	}
 
 	//특정 회원에 대한 리뷰 전체 조회
-	@GetMapping
+	@GetMapping("/reviewee/{reviewee-id:[0-9+]}")
 	public ResponseEntity<?> findAllByMember(@Positive @RequestParam(name = "page") int page,
-		@Positive @RequestParam(name = "size") int size, @RequestBody ReviewDto.Get body, @LoginMember Member member) {
+		@Positive @RequestParam(name = "size") int size, @PathVariable("reviewee-id") Long revieweeId,
+		@LoginMember Member member) {
 
-		Page<Review> reviewPage = reviewService.findReviewByRevieweeId(member, body.getRevieweeId(), page - 1, size);
+		Page<Review> reviewPage = reviewService.findReviewByRevieweeId(member, revieweeId, page - 1, size);
 		List<Review> reviews = reviewPage.getContent();
 		List<ReviewDto.Response> response = mapper.reviewToReviewDtoResponse(reviews);
 

--- a/azit-back/src/test/java/com/codestates/azitserver/domain/club/controller/ClubControllerTest.java
+++ b/azit-back/src/test/java/com/codestates/azitserver/domain/club/controller/ClubControllerTest.java
@@ -317,20 +317,6 @@ class ClubControllerTest implements ClubControllerTestHelper {
 	}
 
 	@Test
-	void getClubByMemberRecommend() {
-
-		// TODO : implement
-
-	}
-
-	@Test
-	void getClubByMemberId() {
-
-		// TODO : implement
-
-	}
-
-	@Test
 	void search() throws Exception {
 		// given
 		MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();

--- a/azit-back/src/test/java/com/codestates/azitserver/domain/club/controller/ClubMemberControllerTest.java
+++ b/azit-back/src/test/java/com/codestates/azitserver/domain/club/controller/ClubMemberControllerTest.java
@@ -177,4 +177,31 @@ class ClubMemberControllerTest implements ClubMemberControllerTestHelper {
 				)
 			));
 	}
+
+	@Test
+	void deleteClubMembers() throws Exception {
+		// given
+		Long clubId = 1L;
+		Long memberId = 1L;
+
+		doNothing().when(clubMemberService)
+			.deleteClubMember(Mockito.any(Member.class), Mockito.anyLong(), Mockito.anyLong());
+
+		// when
+		ResultActions actions = mockMvc.perform(
+			deleteRequestBuilder(getClubMemberUrl("signups", "{member-id}"), clubId, memberId)
+				.header("Authorization", "Required JWT access token"));
+
+		// then
+		actions.andDo(print())
+			.andExpect(status().isNoContent())
+			.andDo(getDefaultDocument("delete-club-members",
+					requestHeaders(headerWithName("Authorization").description("Jwt Access Token")),
+					pathParameters(List.of(
+						parameterWithName("club-id").description("아지트 고유 식별자"),
+						parameterWithName("member-id").description("회원 고유 식별자"))
+					)
+				)
+			);
+	}
 }

--- a/azit-back/src/test/java/com/codestates/azitserver/domain/club/controller/descriptor/ClubMemberFieldDescriptor.java
+++ b/azit-back/src/test/java/com/codestates/azitserver/domain/club/controller/descriptor/ClubMemberFieldDescriptor.java
@@ -32,7 +32,8 @@ public class ClubMemberFieldDescriptor {
 		).andWithPrefix("data.member.",
 			fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("회원 고유 식별자"),
 			fieldWithPath("email").type(JsonFieldType.STRING).description("회원 이메일"),
-			fieldWithPath("nickname").type(JsonFieldType.STRING).description("닉네임")
+			fieldWithPath("nickname").type(JsonFieldType.STRING).description("닉네임"),
+			fieldWithPath("aboutMe").type(JsonFieldType.STRING).description("자기소개")
 		).and(
 			fieldWithPath("data.member.fileInfo").type(JsonFieldType.OBJECT).description("프로필 사진")
 		).andWithPrefix("data.member.fileInfo.",
@@ -54,7 +55,8 @@ public class ClubMemberFieldDescriptor {
 		).andWithPrefix("data[].member.",
 			fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("회원 고유 식별자"),
 			fieldWithPath("email").type(JsonFieldType.STRING).description("회원 이메일"),
-			fieldWithPath("nickname").type(JsonFieldType.STRING).description("닉네임")
+			fieldWithPath("nickname").type(JsonFieldType.STRING).description("닉네임"),
+			fieldWithPath("aboutMe").type(JsonFieldType.STRING).description("자기소개")
 		).and(
 			fieldWithPath("data[].member.fileInfo").type(JsonFieldType.OBJECT).description("프로필 사진")
 		).andWithPrefix("data[].member.fileInfo.",

--- a/azit-back/src/test/java/com/codestates/azitserver/domain/review/controller/ReviewControllerTest.java
+++ b/azit-back/src/test/java/com/codestates/azitserver/domain/review/controller/ReviewControllerTest.java
@@ -128,28 +128,29 @@ class ReviewControllerTest implements ReviewControllerTestHelper {
 		queryParams.add("page", "1");
 		queryParams.add("size", "10");
 
-		String content = objectMapper.writeValueAsString(get);
-
 		given(reviewService.findReviewByRevieweeId(Mockito.any(), Mockito.anyLong(), Mockito.anyInt(),
 			Mockito.anyInt())).willReturn(reviewPage);
 		given(mapper.reviewToReviewDtoResponse(Mockito.anyList())).willReturn(List.of(response));
 
 		// when
-		ResultActions actions = mockMvc.perform(getRequestBuilder(getReviewUrl(), queryParams, content)
-			.header("Authorization", "Required JWT access token(Optional)"));
+		ResultActions actions = mockMvc.perform(
+			getRequestBuilder(getReviewUrl() + "/reviewee/{reviewee-id}", queryParams, 1L)
+				.header("Authorization", "Required JWT access token(Optional)"));
 
 		// then
 		actions.andDo(print())
 			.andExpect(status().isOk())
 			.andDo(getDefaultDocument("find-all-by-member",
 					requestHeaders(headerWithName("Authorization").description("Jwt Access Token(Optional)")),
+					pathParameters(List.of(
+						parameterWithName("reviewee-id").description("리뷰 대상자 고유 식별자"))
+					),
 					requestParameters(
 						List.of(
 							parameterWithName("page").description("Page 번호"),
 							parameterWithName("size").description("Page 크기")
 						)
 					),
-					ReviewFieldsDescriptor.getSetRequestFieldsSnippet(),
 					ReviewFieldsDescriptor.getMultiResponseFieldsSnippet()
 				)
 			);

--- a/azit-back/src/test/java/com/codestates/azitserver/domain/review/controller/ReviewControllerTest.java
+++ b/azit-back/src/test/java/com/codestates/azitserver/domain/review/controller/ReviewControllerTest.java
@@ -76,7 +76,7 @@ class ReviewControllerTest implements ReviewControllerTestHelper {
 		given(reviewService.createReview(Mockito.any(), Mockito.any(Review.class))).willReturn(review);
 		given(mapper.reviewToReviewDtoResponse(Mockito.any(Review.class))).willReturn(response);
 
-		String content = objectMapper.writeValueAsString(post);
+		String content = objectMapper.writeValueAsString(List.of(post));
 
 		// when
 		ResultActions actions = mockMvc.perform(postRequestBuilder(createURI(getReviewUrl()), content)
@@ -88,7 +88,7 @@ class ReviewControllerTest implements ReviewControllerTestHelper {
 			.andDo(getDefaultDocument("post-review",
 					requestHeaders(headerWithName("Authorization").description("Jwt Access Token")),
 					ReviewFieldsDescriptor.getPostRequestFieldsSnippet(),
-					ReviewFieldsDescriptor.getSingleResponseFieldsSnippet()
+					ReviewFieldsDescriptor.getSingleArrayResponseFieldsSnippet()
 				)
 			);
 	}

--- a/azit-back/src/test/java/com/codestates/azitserver/domain/review/descriptor/ReviewFieldsDescriptor.java
+++ b/azit-back/src/test/java/com/codestates/azitserver/domain/review/descriptor/ReviewFieldsDescriptor.java
@@ -11,6 +11,8 @@ import org.springframework.restdocs.snippet.Snippet;
 public class ReviewFieldsDescriptor {
 	public static RequestFieldsSnippet getPostRequestFieldsSnippet() {
 		return requestFields(
+			fieldWithPath("[]").description("요청 데이터 배열")
+		).andWithPrefix("[].",
 			fieldWithPath("reviewerId").type(JsonFieldType.NUMBER).description("리뷰 쓰는 사용자 고유 식별자"),
 			fieldWithPath("revieweeId").type(JsonFieldType.NUMBER).description("리뷰 대상자 고유 식별자"),
 			fieldWithPath("clubId").type(JsonFieldType.NUMBER).description("리뷰어, 리뷰이가 참여하고 있는 아지트 고유 식별자"),
@@ -49,6 +51,26 @@ public class ReviewFieldsDescriptor {
 		).and(
 			fieldWithPath("data.club").type(JsonFieldType.OBJECT).description("리뷰어, 리뷰이가 참여하고 있는 아지트 데이터")
 		).andWithPrefix("data.club.",
+			fieldWithPath("clubId").type(JsonFieldType.NUMBER).description("아지트 고유 식별자"),
+			fieldWithPath("clubName").type(JsonFieldType.STRING).description("아지트 이름"),
+			fieldWithPath("meetingDate").type(JsonFieldType.STRING).description("약속 날짜")
+		);
+	}
+
+	public static ResponseFieldsSnippet getSingleArrayResponseFieldsSnippet() {
+		return responseFields(
+			fieldWithPath("data").type(JsonFieldType.ARRAY).description("응답 데이터")
+		).andWithPrefix("data[].",
+			fieldWithPath("reviewId").type(JsonFieldType.NUMBER).description("리뷰 고유 식별자"),
+			fieldWithPath("revieweeId").type(JsonFieldType.NUMBER).description("리뷰 대상자 고유 식별자"),
+			fieldWithPath("commentCategory").type(JsonFieldType.STRING).description("리뷰 카테고리(enum의 value값)"),
+			fieldWithPath("commentBody").type(JsonFieldType.STRING).description("상세 리뷰 내용"),
+			fieldWithPath("reviewStatus").type(JsonFieldType.BOOLEAN)
+				.description("리뷰 숨김처리 여부")
+				.attributes(key("constraints").value("true: 숨김 | false: 공개"))
+		).and(
+			fieldWithPath("data[].club").type(JsonFieldType.OBJECT).description("리뷰어, 리뷰이가 참여하고 있는 아지트 데이터")
+		).andWithPrefix("data[].club.",
 			fieldWithPath("clubId").type(JsonFieldType.NUMBER).description("아지트 고유 식별자"),
 			fieldWithPath("clubName").type(JsonFieldType.STRING).description("아지트 이름"),
 			fieldWithPath("meetingDate").type(JsonFieldType.STRING).description("약속 날짜")

--- a/azit-back/src/test/java/com/codestates/azitserver/domain/stub/MemberStubData.java
+++ b/azit-back/src/test/java/com/codestates/azitserver/domain/stub/MemberStubData.java
@@ -137,6 +137,7 @@ public class MemberStubData {
         response.setFileInfo(FileInfoStubData.getFileInfoDtoResponse());
         response.setEmail("stubmember@naver.com");
         response.setNickname("김스텁");
+        response.setAboutMe("김스텁의 자기소개");
 
         return response;
     }

--- a/azit-back/src/test/java/com/codestates/azitserver/global/utils/ControllerTestHelper.java
+++ b/azit-back/src/test/java/com/codestates/azitserver/global/utils/ControllerTestHelper.java
@@ -49,15 +49,6 @@ public interface ControllerTestHelper {
 			.accept(MediaType.APPLICATION_JSON);
 	}
 
-	default MockHttpServletRequestBuilder getRequestBuilder(String url, MultiValueMap<String, String> queryParams, String content, Object... urlVariables) {
-		return get(url, urlVariables)
-			.queryParams(queryParams)
-			.accept(MediaType.APPLICATION_JSON)
-			.contentType(MediaType.APPLICATION_JSON)
-			.characterEncoding(StandardCharsets.UTF_8)
-			.content(content);
-	}
-
 	default MockHttpServletRequestBuilder getRequestBuilder(String url, long resourceId) {
 		return get(url, resourceId)
 			.accept(MediaType.APPLICATION_JSON);

--- a/azit-back/src/test/java/com/codestates/azitserver/global/utils/ControllerTestHelper.java
+++ b/azit-back/src/test/java/com/codestates/azitserver/global/utils/ControllerTestHelper.java
@@ -63,8 +63,8 @@ public interface ControllerTestHelper {
 			.content(content);
 	}
 
-	default MockHttpServletRequestBuilder deleteRequestBuilder(String url, long resourceId) {
-		return delete(url, resourceId);
+	default MockHttpServletRequestBuilder deleteRequestBuilder(String url, Object... urlVariables) {
+		return delete(url, urlVariables);
 	}
 
 	default URI createURI(String url) {


### PR DESCRIPTION
## 개요
리뷰 도메인 및 아지트 참여 도메인 수정사항 업테이드 합니다. 

## 주요 작업사항
- 아지트 참여신청 응답값에 회원 자기소개 정보 추가
- 아지트 신청 후 사용자가 자발적으로 아지트 참여 취소할 수 있는 api 추가
  - 취소는 본인만 가능합니다.(jwt로 본인 인증이 이루어집니다.)
  - 아지트 신청 취소는 회원의 아지트 참여 상태값이 CLUB_WAITING 또는 CLUB_JOINED일 경우 가능합니다.
  - 호스트에 의한 거절 또는 강퇴와 달리 신청자가 아지트 신청 취소를 하면 이후 해당 아지트에 재신청이 가능합니다.

- 리뷰 작성시 기존 개별적으로 리뷰 데이터를 요청값으로 받는 것이 아닌 전체 리뷰를 배열로 받아 한번에 처리하도록 수정
  - TODO: 현재는 요청 처리 중간에 리뷰 저장을 성공적으로 하지 못할시 이전 내용들이 롤백되지 않음(추후 필히 개선해야할 사항)
- 특정 회원에 대한 전체 리뷰 조회 도메인 변경
  - get 요청 안에 요청 body가 아닌 파라미터로 내용을 전달받도록 api 도메인 수정


## 기능 외 변경사항(개발 범위 외 수정된 사항 등)

## 기타