### PR TITLE
[auth/hotfix] api 주소 소문자로 변경. 테스트위해 임시로 토큰시간 2분으로 임시 설정

### DIFF
--- a/azit-back/src/main/java/com/codestates/azitserver/domain/auth/controller/AuthController.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/auth/controller/AuthController.java
@@ -60,7 +60,7 @@ public class AuthController {
 		return new ResponseEntity<>(HttpStatus.OK);
 	}
 
-	@PostMapping("/reIssue")
+	@PostMapping("/re-issue")
 	public ResponseEntity reIssueToken(HttpServletRequest request, HttpServletResponse response,
 		@RequestBody AuthDto.ReissueToken reissueInfo) {
 		AuthResponseDto.TokenResponse tokenResponse = authService.reIssueToken(request, reissueInfo);

--- a/azit-back/src/main/resources/application.yml
+++ b/azit-back/src/main/resources/application.yml
@@ -28,7 +28,7 @@ server:
 
 jwt:
   secret-key: ${JWT_SECRET_KEY:DOFHUEWJKF8971938576439NGBJCBGVYUGFTYSFRC56TUH8NUK6JNYO9UGV8WE678REFKUG3K6HG9283} # dummy
-  access-token-expiration-minutes: 30
+  access-token-expiration-minutes: 2 # 30
   refresh-token-expiration-minutes: 420
 
 mail:

--- a/azit-back/src/test/java/com/codestates/azitserver/domain/auth/authControllerTest.java
+++ b/azit-back/src/test/java/com/codestates/azitserver/domain/auth/authControllerTest.java
@@ -230,7 +230,7 @@ public class authControllerTest {
 		// when
 		ResultActions actions =
 			mockMvc.perform(
-				post("/api/auth/reIssue")
+				post("/api/auth/re-issue")
 					.header("Refresh", "Required JWT refresh token")
 					.contentType(MediaType.APPLICATION_JSON)
 					.characterEncoding("UTF-8")


### PR DESCRIPTION
## 개요
토큰 재발급 api 주소 소문자로 변경

## 주요 작업사항
토큰 재발급 api 주소 변경
테스트 원활을 위하여 토큰 시간 임시로 줄였습니다.
## 기능 외 변경사항(개발 범위 외 수정된 사항 등)

## 기타