### PR TITLE
[auth/hotfix] 토큰 재발급 방식 변경

### DIFF
--- a/azit-back/src/docs/asciidoc/index.adoc
+++ b/azit-back/src/docs/asciidoc/index.adoc
@@ -104,8 +104,8 @@ include::{snippets}/token-reIssue/curl-request.adoc[]
 .http-request
 include::{snippets}/token-reIssue/http-request.adoc[]
 
-.request-fields
-include::{snippets}/token-reIssue/request-fields.adoc[]
+.path-parameters
+include::{snippets}/token-reIssue/path-parameters.adoc[]
 
 .request-headers
 include::{snippets}/token-reIssue/request-headers.adoc[]
@@ -286,8 +286,8 @@ include::{snippets}/post-member-report/request-fields.adoc[]
 .http-response
 include::{snippets}/post-member-report/http-response.adoc[]
 
-.response-fields
-include::{snippets}/post-member-report/response-fields.adoc[]
+// .response-fields
+// include::{snippets}/post-member-report/response-fields.adoc[]
 
 == 아지트(모임)
 

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/auth/controller/AuthController.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/auth/controller/AuthController.java
@@ -6,6 +6,7 @@ import javax.validation.constraints.Positive;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -60,14 +61,14 @@ public class AuthController {
 		return new ResponseEntity<>(HttpStatus.OK);
 	}
 
-	@PostMapping("/re-issue")
+	@GetMapping("/re-issue/{email:.+}")
 	public ResponseEntity reIssueToken(HttpServletRequest request, HttpServletResponse response,
-		@RequestBody AuthDto.ReissueToken reissueInfo) {
-		AuthResponseDto.TokenResponse tokenResponse = authService.reIssueToken(request, reissueInfo);
+		@PathVariable("email") String memberEmail) {
+		AuthResponseDto.TokenResponse tokenResponse = authService.reIssueToken(request, memberEmail);
 		response.setHeader("Authorization", tokenResponse.getAccessToken());
 		response.setHeader("Refresh", tokenResponse.getRefreshToken());
 
-		return new ResponseEntity<>(HttpStatus.CREATED);
+		return new ResponseEntity<>(HttpStatus.OK);
 	}
 
 	//로그아웃

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/auth/dto/AuthDto.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/auth/dto/AuthDto.java
@@ -58,11 +58,4 @@ public class AuthDto {
 		private String email;
 		private String authNum;
 	}
-
-	@Getter
-	@Setter
-	public static class ReissueToken {
-		private String email;
-		private String accessToken;
-	}
 }

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/auth/service/AuthService.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/auth/service/AuthService.java
@@ -167,33 +167,23 @@ public class AuthService {
 
 	/**
 	 * 토큰 재발급
-	 * @param request AccessToken, RefreshToken
+	 * @param request RefreshToken
+	 * @param memberEmail memberEmail (만료된 accessToken 재발급 위함)
 	 * @return 새로운 AccessToken 정보가 담긴 Dto
 	 */
 	@Transactional
-	public AuthResponseDto.TokenResponse reIssueToken(HttpServletRequest request, AuthDto.ReissueToken reissueInfo) {
+	public AuthResponseDto.TokenResponse reIssueToken(HttpServletRequest request, String memberEmail) {
 		String refreshToken = request.getHeader("Refresh"); // refreshToken
-		String email = reissueInfo.getEmail(); // 유저 email
-		String accessToken = reissueInfo.getAccessToken(); // 만료된 accessToken
-		accessToken = accessToken.split(" ")[1];
 
 		// Redis에 저장된 email(key값)의 RTK(value값)가 요청 들어온 RTK와 일치하는지 확인
-		if (!redisUtils.getValuebyKey(email).equals(refreshToken)) {
-			throw new BusinessLogicException(ExceptionCode.TOKEN_NOT_FOUND);
+		if (!redisUtils.getValuebyKey(memberEmail).equals(refreshToken)) {
+			throw new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND);
 		}
 
 		// logout되면 redis에서 refreshToken 삭제되어 재발급 안 됨
-		if (redisUtils.isExists(email)) {
-			Member findMember = findVerifiedMemberByEmail(email);
+		if (redisUtils.isExists(memberEmail)) {
+			Member findMember = findVerifiedMemberByEmail(memberEmail);
 			String NewAccessToken = delegateAccessToken(findMember);
-
-			// 만약 accessToken이 만료되지 않았으면 blackList 등록
-			try {
-				Long expiration = jwtTokenizer.getATKExpiration(accessToken);
-				redisUtils.setData(accessToken, "blackList", expiration);
-			} catch (Exception e) {
-				log.info("accessToken이 만료되어 blackList로 등록하지 않습니다.");
-			}
 
 			AuthResponseDto.TokenResponse tokenResponse = new AuthResponseDto.TokenResponse();
 			tokenResponse.setAccessToken("Bearer " + NewAccessToken);

--- a/azit-back/src/main/java/com/codestates/azitserver/global/config/SecurityConfig.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/global/config/SecurityConfig.java
@@ -112,7 +112,7 @@ public class SecurityConfig {
 				/*======auth======*/
 				.antMatchers(HttpMethod.POST, "/api/auth/login").permitAll() // 로그인
 				.antMatchers(HttpMethod.POST, "/api/auth/refresh/**").permitAll() // 비밀번호 찾기
-				.antMatchers(HttpMethod.POST, "/api/auth/re-issue").permitAll() // 토큰 재발급
+				.antMatchers(HttpMethod.GET, "/api/auth/re-issue/**").permitAll() // 토큰 재발급
 
 				.anyRequest().authenticated())
 

--- a/azit-back/src/main/java/com/codestates/azitserver/global/config/SecurityConfig.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/global/config/SecurityConfig.java
@@ -112,7 +112,7 @@ public class SecurityConfig {
 				/*======auth======*/
 				.antMatchers(HttpMethod.POST, "/api/auth/login").permitAll() // 로그인
 				.antMatchers(HttpMethod.POST, "/api/auth/refresh/**").permitAll() // 비밀번호 찾기
-				.antMatchers(HttpMethod.POST, "/api/auth/reIssue").permitAll() // 토큰 재발급
+				.antMatchers(HttpMethod.POST, "/api/auth/re-issue").permitAll() // 토큰 재발급
 
 				.anyRequest().authenticated())
 

--- a/azit-back/src/main/resources/application.yml
+++ b/azit-back/src/main/resources/application.yml
@@ -28,7 +28,7 @@ server:
 
 jwt:
   secret-key: ${JWT_SECRET_KEY:DOFHUEWJKF8971938576439NGBJCBGVYUGFTYSFRC56TUH8NUK6JNYO9UGV8WE678REFKUG3K6HG9283} # dummy
-  access-token-expiration-minutes: 2 # 30
+  access-token-expiration-minutes: 30
   refresh-token-expiration-minutes: 420
 
 mail:

--- a/azit-back/src/main/resources/application.yml
+++ b/azit-back/src/main/resources/application.yml
@@ -28,7 +28,7 @@ server:
 
 jwt:
   secret-key: ${JWT_SECRET_KEY:DOFHUEWJKF8971938576439NGBJCBGVYUGFTYSFRC56TUH8NUK6JNYO9UGV8WE678REFKUG3K6HG9283} # dummy
-  access-token-expiration-minutes: 30
+  access-token-expiration-minutes: 10 # 30 토큰재발급 작업 끝나면 다시 30분으로 늘리겠습니다!
   refresh-token-expiration-minutes: 420
 
 mail:

--- a/azit-back/src/test/java/com/codestates/azitserver/domain/auth/authControllerTest.java
+++ b/azit-back/src/test/java/com/codestates/azitserver/domain/auth/authControllerTest.java
@@ -209,17 +209,12 @@ public class authControllerTest {
 	}
 
 	@Test
-	@DisplayName("reIssueToken")
+	@DisplayName("re-issueToken")
 	public void reIssueTokenTest() throws Exception {
 		// given
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.addHeader("Refresh", "Required JWT refresh token");
-
-		AuthDto.ReissueToken reissueToken = new AuthDto.ReissueToken();
-		reissueToken.setEmail("Required user email");
-		reissueToken.setAccessToken("Required expired access token");
-
-		String content = gson.toJson(reissueToken);
+		String memberEmail = "testMemberEmail@hello.com";
 
 		AuthResponseDto.TokenResponse tokenResponse = new AuthResponseDto.TokenResponse();
 		tokenResponse.setAccessToken("New JWT access token");
@@ -230,24 +225,20 @@ public class authControllerTest {
 		// when
 		ResultActions actions =
 			mockMvc.perform(
-				post("/api/auth/re-issue")
+				get("/api/auth/re-issue/{email:.+}", memberEmail)
 					.header("Refresh", "Required JWT refresh token")
-					.contentType(MediaType.APPLICATION_JSON)
-					.characterEncoding("UTF-8")
 					.with(csrf())
-					.content(content)
 			);
 
 		// then
 		actions
 			.andDo(print())
-			.andExpect(status().isCreated())
+			.andExpect(status().isOk())
 			.andDo(document("token-reIssue",
 				requestHeaders(
 					headerWithName("Refresh").description("Jwt Refresh Token")),
-				requestFields(List.of(
-					fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
-					fieldWithPath("accessToken").type(JsonFieldType.STRING).description("만료된 accessToken"))),
+				pathParameters(List.of(
+					parameterWithName("email").description("Member Email"))),
 				responseHeaders(
 					headerWithName("Authorization").description("Jwt Access Token"),
 					headerWithName("Refresh").description("Jwt Refresh Token")


### PR DESCRIPTION
## 개요
토큰 재발급 방식 변경했습니다.

## 주요 작업사항
ATK 만료 후에도 재발급 받을 수 있도록 로직 구성
토큰 재발급 시 email 받아서 새로 발급해주는 형식으로 변경
Get요청으로 변경
Test, API 수정

## 기능 외 변경사항(개발 범위 외 수정된 사항 등)

## 기타
임시적으로 ATK 만료시간을 10분으로 줄여놨습니다. FE까지 개발 종료되면 다시 30분으로 복구시키겠습니다. 참고부탁드립니다.