### PR TITLE
[Member/follow] 팔로우 도메인 기능 구현

### DIFF
--- a/azit-back/src/main/java/com/codestates/azitserver/domain/follow/controller/FollowController.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/follow/controller/FollowController.java
@@ -97,10 +97,19 @@ public class FollowController {
 	 * @author cryoon
 	 */
 	@GetMapping("/following")
-	public ResponseEntity<?> getFollowings(@Positive @PathVariable("member-id") Long memberId) {
-		// TODO : 단순한 조회가 아닌 리스트 중에 나와의 팔로우 상태값까지 가져와야 합니다.
+	public ResponseEntity<?> getFollowings(@Positive @PathVariable("member-id") Long memberId,
+		@Positive @RequestParam("page") int page, @Positive @RequestParam("size") int size,
+		@LoginMember Member member) {
+		// 본인만 팔로우한 사람들을 볼 수 있습니다.
+		if (!followService.verifyMemberAndMemberId(member, memberId)) {
+			throw new BusinessLogicException(ExceptionCode.MEMBER_VERIFICATION_FAILED);
+		}
 
-		return null;
+		Page<Follow> followPage = followService.findAllMemberFollowing(memberId, page - 1, size);
+		List<Follow> follows = followPage.getContent();
+		List<FollowDto.GetFollowingResponse> responses = mapper.followToFollowDtoFollowingResponse(follows);
+
+		return new ResponseEntity<>(new MultiResponseDto<>(responses, followPage), HttpStatus.OK);
 	}
 
 	/**

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/follow/controller/FollowController.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/follow/controller/FollowController.java
@@ -104,6 +104,24 @@ public class FollowController {
 	}
 
 	/**
+	 * 팔로우 정보를 조회해서 현재 로그인한 유저가 이 사람을 팔로우했는지 확인합니다.
+	 * @param memberId 팔로우 했는지 확인하고싶은 회원 고유 식별자
+	 * @param member 현재 로그인한 유저
+	 * @return 팔로우를 했는지 하지 않았는지 boolean 결과값을 응답으로 전달합니다.
+	 */
+	@GetMapping("follow-status")
+	public ResponseEntity<?> getFollowStatus(@Positive @PathVariable("member-id") Long memberId,
+		@LoginMember Member member) {
+		boolean result = false;
+		if (member != null) {
+			result = followService.isExistFollowByIds(member.getMemberId(), memberId);
+		}
+		FollowDto.FollowStatus response = mapper.getFollowStatus(result);
+
+		return new ResponseEntity<>(new SingleResponseDto<>(response), HttpStatus.OK);
+	}
+
+	/**
 	 * 나를 팔로우 한 사람들 중 내가 강제로 팔로우를 해제합니다.
 	 * @param memberId 나.
 	 * @param followId 나를 팔로우 한 리스트중 해제하고 싶은 팔로우 고유 식별자
@@ -118,7 +136,7 @@ public class FollowController {
 		}
 
 		followService.deleteFollowByFollowId(followId);
-		
+
 		return new ResponseEntity<>(HttpStatus.NO_CONTENT);
 	}
 

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/follow/controller/FollowController.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/follow/controller/FollowController.java
@@ -85,7 +85,7 @@ public class FollowController {
 		@Positive @RequestParam("page") int page, @Positive @RequestParam("size") int size) {
 		Page<Follow> followPage = followService.findAllMemberFollower(memberId, page - 1, size);
 		List<Follow> follows = followPage.getContent();
-		List<FollowDto.Response> responses = mapper.followToFollowDtoResponse(follows);
+		List<FollowDto.GetFollowerResponse> responses = mapper.followToFollowDtoGetFollowerResponse(follows);
 
 		return new ResponseEntity<>(new MultiResponseDto<>(responses, followPage), HttpStatus.OK);
 	}
@@ -111,8 +111,15 @@ public class FollowController {
 	 * @author cryoon
 	 */
 	@DeleteMapping("/follower/{follow-id:[0-9]+}")
-	public void deleteFollowers(@Positive @PathVariable("member-id") Long memberId,
+	public ResponseEntity<?> deleteFollowers(@Positive @PathVariable("member-id") Long memberId,
 		@Positive @PathVariable("follow-id") Long followId, @LoginMember Member member) {
+		if (!followService.verifyMemberAndMemberId(member, memberId)) {
+			throw new BusinessLogicException(ExceptionCode.MEMBER_VERIFICATION_FAILED);
+		}
+
+		followService.deleteFollowByFollowId(followId);
+		
+		return new ResponseEntity<>(HttpStatus.NO_CONTENT);
 	}
 
 }

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/follow/dto/FollowDto.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/follow/dto/FollowDto.java
@@ -2,11 +2,18 @@ package com.codestates.azitserver.domain.follow.dto;
 
 import com.codestates.azitserver.domain.member.dto.MemberDto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 public class FollowDto {
+	@Getter
+	@AllArgsConstructor
+	public static class FollowStatus {
+		private boolean result;
+	}
+
 	@Getter
 	@Setter
 	@NoArgsConstructor

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/follow/dto/FollowDto.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/follow/dto/FollowDto.java
@@ -15,4 +15,12 @@ public class FollowDto {
 		private MemberDto.ClubMemberMemberResponse follower;
 		private MemberDto.ClubMemberMemberResponse followee;
 	}
+
+	@Getter
+	@Setter
+	@NoArgsConstructor
+	public static class GetFollowerResponse {
+		private Long followId;
+		private MemberDto.ClubMemberMemberResponse follower;
+	}
 }

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/follow/dto/FollowDto.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/follow/dto/FollowDto.java
@@ -30,4 +30,13 @@ public class FollowDto {
 		private Long followId;
 		private MemberDto.ClubMemberMemberResponse follower;
 	}
+
+	@Getter
+	@Setter
+	@NoArgsConstructor
+	public static class GetFollowingResponse {
+		private Long followId;
+		private MemberDto.ClubMemberMemberResponse followee;
+		private Boolean matpal;
+	}
 }

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/follow/entity/Follow.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/follow/entity/Follow.java
@@ -10,12 +10,14 @@ import javax.persistence.ManyToOne;
 import com.codestates.azitserver.domain.common.Auditable;
 import com.codestates.azitserver.domain.member.entity.Member;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
 @NoArgsConstructor
+@AllArgsConstructor
 public class Follow extends Auditable {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -29,6 +31,8 @@ public class Follow extends Auditable {
 	@JoinColumn(name = "FOLLOWEE_ID")
 	private Member followee;
 
+	private Boolean matpal;
+
 	public void setFollower(Member member) {
 		this.follower = member;
 		if (!this.follower.getFollowerList().contains(this)) {
@@ -41,6 +45,10 @@ public class Follow extends Auditable {
 		if (!this.followee.getFollowingList().contains(this)) {
 			this.followee.getFollowingList().add(this);
 		}
+	}
+
+	public Boolean getMatpal() {
+		return matpal != null;
 	}
 
 	//*** Builder ***//

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/follow/mapper/FollowMapper.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/follow/mapper/FollowMapper.java
@@ -3,6 +3,7 @@ package com.codestates.azitserver.domain.follow.mapper;
 import java.util.List;
 
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 import com.codestates.azitserver.domain.follow.dto.FollowDto;
 import com.codestates.azitserver.domain.follow.entity.Follow;
@@ -15,6 +16,9 @@ public interface FollowMapper {
 	List<FollowDto.Response> followToFollowDtoResponse(List<Follow> follow);
 
 	List<FollowDto.GetFollowerResponse> followToFollowDtoGetFollowerResponse(List<Follow> follows);
+
+	@Mapping(target = "matpal", expression = "java(follow.getMatpal())")
+	List<FollowDto.GetFollowingResponse> followToFollowDtoFollowingResponse(List<Follow> follows);
 
 	default FollowDto.FollowStatus getFollowStatus(boolean result) {
 		return new FollowDto.FollowStatus(result);

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/follow/mapper/FollowMapper.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/follow/mapper/FollowMapper.java
@@ -15,4 +15,8 @@ public interface FollowMapper {
 	List<FollowDto.Response> followToFollowDtoResponse(List<Follow> follow);
 
 	List<FollowDto.GetFollowerResponse> followToFollowDtoGetFollowerResponse(List<Follow> follows);
+
+	default FollowDto.FollowStatus getFollowStatus(boolean result) {
+		return new FollowDto.FollowStatus(result);
+	}
 }

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/follow/mapper/FollowMapper.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/follow/mapper/FollowMapper.java
@@ -13,4 +13,6 @@ public interface FollowMapper {
 	FollowDto.Response followToFollowDtoResponse(Follow follow);
 
 	List<FollowDto.Response> followToFollowDtoResponse(List<Follow> follow);
+
+	List<FollowDto.GetFollowerResponse> followToFollowDtoGetFollowerResponse(List<Follow> follows);
 }

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/follow/repository/FollowRepository.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/follow/repository/FollowRepository.java
@@ -1,10 +1,10 @@
 package com.codestates.azitserver.domain.follow.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -15,7 +15,14 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
 	@Query("select f from Follow f where f.follower.memberId = :followerId and f.followee.memberId = :followeeId")
 	Optional<Follow> findByFollowerIdAndFolloweeId(Long followerId, Long followeeId);
 
-	Page<Follow> findAllByFollower(Member member, Pageable pageable);
-
 	Page<Follow> findAllByFollowee(Member member, PageRequest pageable);
+
+	// SELECT F1.FOLLOW_ID, F1.FOLLOWER_ID, F1.FOLLOWEE_ID, F1.CREATED_AT,
+	// (SELECT TRUE FROM FOLLOW F2 WHERE F1.FOLLOWER_ID = F2.FOLLOWEE_ID AND F1.FOLLOWEE_ID=F2.FOLLOWER_ID) "MATPAL"
+	// FROM FOLLOW F1
+	// WHERE FOLLOWER_ID = 1;
+	@Query("select new Follow (f1.followId, f1.follower, f1.followee, "
+		+ "(select true from Follow f2 where f1.follower = f2.followee and f1.followee = f2.follower)) "
+		+ "from Follow f1 where f1.follower = :member ")
+	List<Follow> findAllByFollower(Member member);
 }

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/follow/repository/FollowRepository.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/follow/repository/FollowRepository.java
@@ -3,6 +3,7 @@ package com.codestates.azitserver.domain.follow.repository;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -15,4 +16,6 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
 	Optional<Follow> findByFollowerIdAndFolloweeId(Long followerId, Long followeeId);
 
 	Page<Follow> findAllByFollower(Member member, Pageable pageable);
+
+	Page<Follow> findAllByFollowee(Member member, PageRequest pageable);
 }

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/follow/service/FollowService.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/follow/service/FollowService.java
@@ -1,8 +1,11 @@
 package com.codestates.azitserver.domain.follow.service;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
@@ -88,6 +91,28 @@ public class FollowService {
 
 		return followRepository.findAllByFollowee(member,
 			PageRequest.of(page, size, Sort.by("createdAt").descending()));
+	}
+
+	public Page<Follow> findAllMemberFollowing(Long memberId, int page, int size) {
+		Member member = memberService.findExistingMember(memberId);
+
+		List<Follow> follower = followRepository.findAllByFollower(member);
+
+		// JPQL sub query를 통해서 값을 구하니 pagination이 안 돼서 직접 구현
+		PageRequest pageRequest = PageRequest.of(page, size);
+		final int start = (int)pageRequest.getOffset();
+		final int end = Math.min((start + pageRequest.getPageSize()), follower.size());
+
+		List<Follow> subList;
+		try {
+			subList = follower.subList(start, end);
+		} catch (Exception e) {
+			subList = new ArrayList<>();
+		}
+
+		final Page<Follow> followPage = new PageImpl<>(subList, pageRequest, follower.size());
+
+		return followPage;
 	}
 
 	/**

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/follow/service/FollowService.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/follow/service/FollowService.java
@@ -76,11 +76,40 @@ public class FollowService {
 		return optionalFollow.orElseThrow(() -> new BusinessLogicException(ExceptionCode.FOLLOW_NOT_FOUND));
 	}
 
+	/**
+	 * member id의 회원을 팔로우한(followee가 member-id) 팔로우 정보를 조회합니다.
+	 * @param memberId 회원 고유식별자
+	 * @param page 페이지 번호
+	 * @param size 페이지 크기
+	 * @return 페이지네이션이 된 팔로우 정보 리스트
+	 */
 	public Page<Follow> findAllMemberFollower(Long memberId, int page, int size) {
 		Member member = memberService.findExistingMember(memberId);
 
-		return followRepository.findAllByFollower(member,
+		return followRepository.findAllByFollowee(member,
 			PageRequest.of(page, size, Sort.by("createdAt").descending()));
+	}
+
+	/**
+	 * follow id를 통해 데이터를 삭제합니다.
+	 * @param followId 팔로우 고유 식별자
+	 * @author cryoon
+	 */
+	public void deleteFollowByFollowId(Long followId) {
+		Follow follow = findFollowByFollowId(followId);
+
+		followRepository.deleteById(followId);
+	}
+
+	/**
+	 * follow id를 통해 해당되는 데이터를 조회합니다.
+	 * @param followId 팔로우 고유 식별자
+	 * @return id와 일치하는 팔로우 객체
+	 * @author cryoon
+	 */
+	public Follow findFollowByFollowId(Long followId) {
+		Optional<Follow> optionalFollow = followRepository.findById(followId);
+		return optionalFollow.orElseThrow(() -> new BusinessLogicException(ExceptionCode.FOLLOW_NOT_FOUND));
 	}
 
 	//*** verfification ***//

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/follow/service/FollowService.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/follow/service/FollowService.java
@@ -122,6 +122,9 @@ public class FollowService {
 	 * @author cryoon
 	 */
 	public boolean verifyMemberAndMemberId(Member member, Long memberId) {
+		if (member == null) {
+			throw new BusinessLogicException(ExceptionCode.MEMBER_VERIFICATION_FAILED);
+		}
 		return member.getMemberId().equals(memberId);
 	}
 

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/member/dto/MemberDto.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/member/dto/MemberDto.java
@@ -122,6 +122,8 @@ public class MemberDto {
 		private Integer reputation;
 		private Member.MemberStatus memberStatus;
 		private List<Long> categorySmallIdList;
+		private Integer follower;
+		private Integer following;
 
 	}
 

--- a/azit-back/src/main/java/com/codestates/azitserver/domain/member/mapper/MemberMapper.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/domain/member/mapper/MemberMapper.java
@@ -21,6 +21,8 @@ public interface MemberMapper {
 	@Mapping(target = "reputation", ignore = true)
 	Member memberPatchDtoToMember(MemberDto.Patch memberPatchDto);
 
+	@Mapping(target = "follower", expression = "java(member.getFollowerList().size())")
+	@Mapping(target = "following", expression = "java(member.getFollowingList().size())")
 	MemberDto.Response memberToMemberResponseDto(Member member);
 
 	List<MemberDto.Response> membersToMemberResponseDtos(List<Member> members);

--- a/azit-back/src/main/java/com/codestates/azitserver/global/config/SecurityConfig.java
+++ b/azit-back/src/main/java/com/codestates/azitserver/global/config/SecurityConfig.java
@@ -80,6 +80,7 @@ public class SecurityConfig {
 
 				/*======follow======*/
 				.antMatchers(HttpMethod.GET, "/api/members/{\\d+}/follower").permitAll() // 팔로우 관련 조회
+				.antMatchers(HttpMethod.GET, "/api/members/{\\d+}/follow-status").permitAll() // 팔로우 여부 확인
 
 				/*==========member==========*/
 				.antMatchers(HttpMethod.GET, "/api/members/nickname/**").permitAll() // 중복체크


### PR DESCRIPTION
## 개요
이전 pr #335  과 더불어 
사용자간 팔로우/팔로잉 기능을 모두 구현하였습니다. 

## 주요 작업사항
- 사용자 팔로우/언팔로우(이전 pr)
- 나를 팔로우한 사용자들 조회(이전 pr)
- 나를 팔로우한 사람들 중 나를 팔로우 해제(이전 pr)
- 현재 로그인한 유저가 특정 회원과 팔로우 관계인지 확인
- 내가 팔로우한 사용자들 조회 + 맞팔인지 아닌지 기능
- 회원 정보에 팔로워, 팔로우 숫자 반영

## 기능 외 변경사항(개발 범위 외 수정된 사항 등)

## 기타
테스트 코드는 추후 작성 예정 클라이언트 작업을 위해 먼저 업로드합니다.