### PR TITLE
[fix] 회원 가입 중복 검사 및 관련 버튼 이벤트 수정

### DIFF
--- a/azit-front/src/pages/Signup.js
+++ b/azit-front/src/pages/Signup.js
@@ -65,82 +65,102 @@ const Signup = () => {
     }
   }
 
+  const ConfirmAvailableCheckclick = () => {
+    if(nicknameChecked === false || emailChecked === false) {
+      alert("닉네임 및 이메일 중복 확인이 필요합니다.")
+    } 
+  }
+
   return (
-    <>
-    <Header title="회원가입"/>
-    <SignupForm onSubmit={handleSubmit(data => SignupButtonClick(data))}>
-      <SignupInputContainer>
-        <SignupInputWrap>
-          <label htmlFor="nickname">사용할 닉네임을 입력해 주세요.</label>
-          <input 
-            type='text' 
-            id='nickname' 
-            autoComplete="off"
-            placeholder="영어,한글,-,_을 포함한 2~8글자로 작성해 주세요."
-            {...register('nickname', {
-              required: true,
-              pattern: nicknameRegExp
-            })}></input>
-            <button onClick={nicknameCheckBtnClick} className={nicknameRegExp.test(nickname) ? "nicknameCheckBtn" : "disabled"}>중복확인</button>
-            <div className={nicknameChecked ? "hidden" : "errorMessage"}>닉네임 중복검사가 필요합니다.</div>
-            {errors.nickname?.type === 'required' && <div className="errorMessage">닉네임을 입력해주세요.</div>}
-            {errors.nickname?.type === 'pattern' && <div className="errorMessage">영어,한글,-,_을 포함한 2~8글자로 작성해 주세요.</div>}
-        </SignupInputWrap>
-        <SignupInputWrap>
-          <label htmlFor="email">사용할 이메일을 입력해 주세요.</label>
-          <input 
-            type='text' 
-            id='email'
-            autoComplete="off"
-            placeholder="test@gmail.com"
-            {...register('email', {
-              required: true,
-              pattern: emailRegExp
-            })}></input>
-            <button onClick={emailCheckBtnClick} className={emailRegExp.test(email) ? "emailCheckBtn" : "disabled"}>중복확인</button>
-            <div className={emailChecked ? "hidden" : "errorMessage"}>이메일 중복검사가 필요합니다.</div>
-            {errors.email?.type === 'required' && <div className="errorMessage">이메일을 입력해주세요.</div>}
-            {errors.email?.type === 'pattern' && <div className="errorMessage">이메일 형식이 아닙니다.</div>}
-        </SignupInputWrap>
-        <SignupInputWrap>
-          <label htmlFor="password">사용할 비밀번호를 입력해 주세요.</label>
-          <input 
-            type='password' 
-            id='password' 
-            autoComplete="off"
-            placeholder="특수문자, 문자, 숫자를 포함한 8~16자로 작성해 주세요."
-            {...register('password', {
-              required: true,
-              pattern: passwordRegExp
-            })}></input>
-            {errors.password?.type === 'required' && <div className="errorMessage">비밀번호를 입력해주세요.</div>}
-            {errors.password?.type === 'pattern' && <div className="errorMessage">특수문자, 문자, 숫자를 포함한 8~16자로 작성해 주세요.</div>}
-        </SignupInputWrap>
-        <SignupInputWrap>
-          <label htmlFor="passwordCheck">비밀번호를 확인해 주세요.</label>
-          <input 
-            type='password' 
-            id='passwordCheck' 
-            autoComplete="off"
-            placeholder="비밀번호를 확인해 주세요."
-            {...register('passwordCheck', {
-              required: true,
-              validate: (value) => value === password.current
-            })}
-            />
-          {errors.passwordCheck?.type === 'required' && <div className="errorMessage">비밀번호를 확인해 주세요.</div>}
-          {errors.passwordCheck?.type === 'validate' && <div className="errorMessage">비밀번호가 일치하지 않습니다.</div>}
-        </SignupInputWrap>
-      </SignupInputContainer>
-      <Button 
-        onClick={SignupButtonClick} 
-        type="submit" 
-        title="추가 정보 입력" 
-        state={ !isValid ? "disabled" : "active"}></Button>
-    </SignupForm>
-    </>
+    <Container>
+      <Header title="회원가입"/>
+      <SignupForm onSubmit={handleSubmit(data => SignupButtonClick(data))}>
+        <SignupInputContainer>
+          <SignupInputWrap>
+            <label htmlFor="nickname">사용할 닉네임을 입력해 주세요.</label>
+            <input 
+              type='text' 
+              id='nickname' 
+              autoComplete="off"
+              placeholder="영어,한글,-,_을 포함한 2~8글자로 작성해 주세요."
+              {...register('nickname', {
+                required: true,
+                pattern: nicknameRegExp
+              })}></input>
+              {errors.nickname?.type === 'required' && <div className="errorMessage">닉네임을 입력해주세요.</div>}
+              {errors.nickname?.type === 'pattern' && <div className="errorMessage">영어,한글,-,_을 포함한 2~8글자로 작성해 주세요.</div>}
+          </SignupInputWrap>
+          <SignupInputWrap>
+            <label htmlFor="email">사용할 이메일을 입력해 주세요.</label>
+            <input 
+              type='text' 
+              id='email'
+              autoComplete="off"
+              placeholder="test@gmail.com"
+              {...register('email', {
+                required: true,
+                pattern: emailRegExp
+              })}></input>
+              {errors.email?.type === 'required' && <div className="errorMessage">이메일을 입력해주세요.</div>}
+              {errors.email?.type === 'pattern' && <div className="errorMessage">이메일 형식이 아닙니다.</div>}
+          </SignupInputWrap>
+          <SignupInputWrap>
+            <label htmlFor="password">사용할 비밀번호를 입력해 주세요.</label>
+            <input 
+              type='password' 
+              id='password' 
+              autoComplete="off"
+              placeholder="특수문자, 문자, 숫자를 포함한 8~16자로 작성해 주세요."
+              {...register('password', {
+                required: true,
+                pattern: passwordRegExp
+              })}></input>
+              {errors.password?.type === 'required' && <div className="errorMessage">비밀번호를 입력해주세요.</div>}
+              {errors.password?.type === 'pattern' && <div className="errorMessage">특수문자, 문자, 숫자를 포함한 8~16자로 작성해 주세요.</div>}
+          </SignupInputWrap>
+          <SignupInputWrap>
+            <label htmlFor="passwordCheck">비밀번호를 확인해 주세요.</label>
+            <input 
+              type='password' 
+              id='passwordCheck' 
+              autoComplete="off"
+              placeholder="비밀번호를 확인해 주세요."
+              {...register('passwordCheck', {
+                required: true,
+                validate: (value) => value === password.current
+              })}
+              />
+            {errors.passwordCheck?.type === 'required' && <div className="errorMessage">비밀번호를 확인해 주세요.</div>}
+            {errors.passwordCheck?.type === 'validate' && <div className="errorMessage">비밀번호가 일치하지 않습니다.</div>}
+          </SignupInputWrap>
+        </SignupInputContainer>
+        <Button 
+          onClick={SignupButtonClick} 
+          type="submit" 
+          title="추가 정보 입력" 
+          state={ !isValid ? "disabled" : "active"}></Button>
+      </SignupForm>
+      <NicknameAvailableCheckBtn 
+        onClick={nicknameCheckBtnClick} 
+        color={nicknameRegExp.test(nickname) && !nicknameChecked ? "#BB2649" : "#777777"}
+        pointerEvent={nicknameRegExp.test(nickname) ? "all" : "none"}
+        cursor={nicknameRegExp.test(nickname) ? "pointer" : "auto"}
+        >중복확인</NicknameAvailableCheckBtn>
+      <EmailAvailableCheckBtn 
+        onClick={emailCheckBtnClick} 
+        color={emailRegExp.test(email) && !emailChecked ? "#BB2649" : "#777777"}
+        pointerEvent={emailRegExp.test(email) ? "all" : "none"}
+        cursor={emailRegExp.test(email) ? "pointer" : "auto"}
+        top={errors.nickname ? "16.5rem" : "14.7rem"}
+        >중복확인</EmailAvailableCheckBtn>
+      <ConfirmAvailableCheck onClick={ConfirmAvailableCheckclick} display={nicknameChecked && emailChecked ? "none" : ""}></ConfirmAvailableCheck>
+    </Container>
   ) 
 };
+
+const Container = styled.div`
+  position: relative;
+`
 
 const SignupForm = styled.form`
   display: flex;
@@ -172,32 +192,44 @@ const SignupInputWrap = styled.div`
     color: var(--point-color);
   }
   & > .hidden {
-    display: none;
+    visibility: hidden;
   }
-  & > .nicknameCheckBtn {
-    all: unset;
-    color: var(--point-color);
-    position: absolute;
-    top: 3.7rem;
-    right: 1.5rem;
-    cursor: pointer;
-  }
-  & > .emailCheckBtn {
-    all: unset;
-    color: var(--point-color);
-    position: absolute;
-    top: 3.7rem;
-    right: 1.5rem;
-    cursor: pointer;
-  }
-  & > .disabled {
-    all: unset;
-    color: var(--sub-font-color);
-    position: absolute;
-    top: 3.7rem;
-    right: 1.5rem;
-    pointer-events: none;
-  } 
 `
+
+const NicknameAvailableCheckBtn = styled.button`
+  /* position: absolute; */
+  width: 100%;
+  all: unset;
+  color: ${props => props.color || "#777777"};
+  position: absolute;
+  top: 5.7rem;
+  right: 3.5rem;
+  cursor: ${props => props.cursor || "auto"};
+  pointer-events: ${props => props.pointerEvent || "none"};
+`
+
+const EmailAvailableCheckBtn = styled.button`
+  /* position: absolute; */
+  width: 100%;
+  all: unset;
+  color: ${props => props.color || "#777777"};
+  position: absolute;
+  top: ${props => props.top || "14.7rem"};
+  right: 3.5rem;
+  cursor: ${props => props.cursor};
+  pointer-events: ${props => props.pointerEvent || "none"};
+`
+
+const ConfirmAvailableCheck = styled.div`
+  width: 94%;
+  height: 6rem;
+  z-index: 100;
+  position: absolute;
+  bottom: 1.7rem;
+  left: 1.5rem;
+  display: ${props => props.display || ""};
+`
+
+
 
 export default Signup;


### PR DESCRIPTION
- 회원 가입 닉네임 / 이메일 중복 검사 두가지를 모두 완료할 시에만 추가 정보 버튼이 활성화 되도록 수정
- 중복 검사를 하지 않고 추가 정보 입력 버튼을 눌렀을 때, alert 창이 뜨도록 수정
